### PR TITLE
Fix Vercel 404 on page reload for Vue history routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Issue fixed: deployed app returned 404 when reloading deep links such as /tenant/checkout because Vercel tried to resolve the path as a static file.

Changes:

- Added root-level vercel.json with a rewrite rule routing all paths to /index.html.

- Preserves Vue Router history-mode navigation and allows direct loads/refreshes on nested routes.

Result: hard refresh and direct URL access now load the SPA shell first, then client-side routing resolves tenant/admin paths correctly.