### PR TITLE
Add enforced CSP and security headers for all Vercel routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,31 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://challenges.cloudflare.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://mlaspkufocikfcbjgpof.supabase.co; font-src 'self' data:; connect-src 'self' https://mlaspkufocikfcbjgpof.supabase.co https://itemtraxx-edge-proxy.itemtraxx-co.workers.dev https://api.github.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; manifest-src 'self'; form-action 'self';"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Fixes Aikido finding: 'Content Security Policy (CSP) header not set'.

Implemented response headers at the Vercel edge for every route to establish a baseline browser security policy and reduce XSS/injection risk.

Details:

- Added Content-Security-Policy with explicit allowlists for current runtime integrations (Cloudflare Turnstile, Supabase, Cloudflare Worker proxy, Vercel Analytics/Speed Insights, GitHub API commit check).

- Added supporting hardening headers: Referrer-Policy, X-Content-Type-Options, X-Frame-Options, Permissions-Policy.

- Kept existing SPA history rewrite behavior unchanged.

Validation:

- Production build passes after header configuration update.