### PR TITLE
Implement bulk import UX, advanced filters, idle admin logout, and item terminology updates.

### DIFF
--- a/src/pages/PublicHome.vue
+++ b/src/pages/PublicHome.vue
@@ -162,7 +162,7 @@
           <h3>Clean up messy inventories.</h3>
           <p>
             ItemTraxx aims to solve the issues with messy inventories. Whether you run a small
-            media production company with gear constantly on the move, or a workshop with tools
+            media production company with items constantly on the move, or a workshop with tools
             going in and out, ItemTraxx is the go-to inventory tracking solution.
           </p>
         </article>

--- a/src/pages/super/Admins.vue
+++ b/src/pages/super/Admins.vue
@@ -3,7 +3,7 @@
     <div class="page-nav-left">
       <RouterLink class="button-link" to="/super-admin">Return to Super Admin</RouterLink>
       <RouterLink class="button-link" to="/super-admin/tenants">Tenants</RouterLink>
-      <RouterLink class="button-link" to="/super-admin/gear">All Gear</RouterLink>
+      <RouterLink class="button-link" to="/super-admin/gear">All Items</RouterLink>
       <RouterLink class="button-link" to="/super-admin/students">All Students</RouterLink>
       <RouterLink class="button-link" to="/super-admin/logs">All Logs</RouterLink>
       <RouterLink class="button-link" to="/super-admin/broadcasts">Broadcasts</RouterLink>

--- a/src/pages/super/Broadcasts.vue
+++ b/src/pages/super/Broadcasts.vue
@@ -4,7 +4,7 @@
       <RouterLink class="button-link" to="/super-admin">Return to Super Admin</RouterLink>
       <RouterLink class="button-link" to="/super-admin/tenants">Tenants</RouterLink>
       <RouterLink class="button-link" to="/super-admin/admins">Tenant Admins</RouterLink>
-      <RouterLink class="button-link" to="/super-admin/gear">All Gear</RouterLink>
+      <RouterLink class="button-link" to="/super-admin/gear">All Items</RouterLink>
       <RouterLink class="button-link" to="/super-admin/students">All Students</RouterLink>
       <RouterLink class="button-link" to="/super-admin/logs">All Logs</RouterLink>
     </div>

--- a/src/pages/super/SuperAdminHome.vue
+++ b/src/pages/super/SuperAdminHome.vue
@@ -33,7 +33,7 @@
     <nav class="page-nav-left">
       <RouterLink class="button-link" to="/super-admin/tenants">Tenants</RouterLink>
       <RouterLink class="button-link" to="/super-admin/admins">Tenant Admins</RouterLink>
-      <RouterLink class="button-link" to="/super-admin/gear">All Gear</RouterLink>
+      <RouterLink class="button-link" to="/super-admin/gear">All Items</RouterLink>
       <RouterLink class="button-link" to="/super-admin/students">All Students</RouterLink>
       <RouterLink class="button-link" to="/super-admin/logs">All Logs</RouterLink>
       <RouterLink class="button-link" to="/super-admin/broadcasts">Broadcasts</RouterLink>
@@ -210,7 +210,7 @@
         <thead>
           <tr>
             <th>Tenant</th>
-            <th>Gear</th>
+            <th>Items</th>
             <th>Students</th>
             <th>Active Checkouts</th>
             <th>Overdue</th>

--- a/src/pages/super/SuperLogs.vue
+++ b/src/pages/super/SuperLogs.vue
@@ -3,7 +3,7 @@
     <div class="page-nav-left">
       <RouterLink class="button-link" to="/super-admin">Return to Super Admin</RouterLink>
       <RouterLink class="button-link" to="/super-admin/tenants">Tenants</RouterLink>
-      <RouterLink class="button-link" to="/super-admin/gear">All Gear</RouterLink>
+      <RouterLink class="button-link" to="/super-admin/gear">All Items</RouterLink>
       <RouterLink class="button-link" to="/super-admin/students">All Students</RouterLink>
       <RouterLink class="button-link" to="/super-admin/broadcasts">Broadcasts</RouterLink>
     </div>
@@ -26,7 +26,7 @@
       <p v-if="isLoading" class="muted">Loading logs...</p>
       <p v-else-if="error" class="error">{{ error }}</p>
       <table v-else class="table">
-        <thead><tr><th>Time</th><th>Tenant</th><th>Action</th><th>Gear</th><th>Student</th></tr></thead>
+        <thead><tr><th>Time</th><th>Tenant</th><th>Action</th><th>Item</th><th>Student</th></tr></thead>
         <tbody>
           <tr v-for="row in rows" :key="row.id">
             <td>{{ formatDateTime(row.action_time) }}</td>
@@ -128,12 +128,12 @@ const exportCsv = () => {
     showToast("Export", "No rows to export.");
     return;
   }
-  exportRowsToCsv(`super-logs-page-${page.value}.csv`, ["time", "tenant", "action", "gear_name", "gear_barcode", "student"], rows.value.map((row) => ({
+  exportRowsToCsv(`super-logs-page-${page.value}.csv`, ["time", "tenant", "action", "item_name", "item_barcode", "student"], rows.value.map((row) => ({
     time: formatDateTime(row.action_time),
     tenant: row.tenant?.name ?? row.tenant_id,
     action: row.action_type,
-    gear_name: row.gear?.name ?? "",
-    gear_barcode: row.gear?.barcode ?? "",
+    item_name: row.gear?.name ?? "",
+    item_barcode: row.gear?.barcode ?? "",
     student: row.student ? `${row.student.first_name} ${row.student.last_name} (${row.student.student_id})` : "",
   })));
 };
@@ -143,12 +143,12 @@ const exportPdf = () => {
     showToast("Export", "No rows to export.");
     return;
   }
-  exportRowsToPdf(`super-logs-page-${page.value}.pdf`, "Super Logs Export", ["time", "tenant", "action", "gear_name", "gear_barcode", "student"], rows.value.map((row) => ({
+  exportRowsToPdf(`super-logs-page-${page.value}.pdf`, "Super Logs Export", ["time", "tenant", "action", "item_name", "item_barcode", "student"], rows.value.map((row) => ({
     time: formatDateTime(row.action_time),
     tenant: row.tenant?.name ?? row.tenant_id,
     action: row.action_type,
-    gear_name: row.gear?.name ?? "",
-    gear_barcode: row.gear?.barcode ?? "",
+    item_name: row.gear?.name ?? "",
+    item_barcode: row.gear?.barcode ?? "",
     student: row.student ? `${row.student.first_name} ${row.student.last_name} (${row.student.student_id})` : "",
   })));
 };

--- a/src/pages/super/SuperStudents.vue
+++ b/src/pages/super/SuperStudents.vue
@@ -3,7 +3,7 @@
     <div class="page-nav-left">
       <RouterLink class="button-link" to="/super-admin">Return to Super Admin</RouterLink>
       <RouterLink class="button-link" to="/super-admin/tenants">Tenants</RouterLink>
-      <RouterLink class="button-link" to="/super-admin/gear">All Gear</RouterLink>
+      <RouterLink class="button-link" to="/super-admin/gear">All Items</RouterLink>
       <RouterLink class="button-link" to="/super-admin/logs">All Logs</RouterLink>
       <RouterLink class="button-link" to="/super-admin/broadcasts">Broadcasts</RouterLink>
     </div>

--- a/src/pages/super/Tenants.vue
+++ b/src/pages/super/Tenants.vue
@@ -3,7 +3,7 @@
     <div class="page-nav-left">
       <RouterLink class="button-link" to="/super-admin">Return to Super Admin</RouterLink>
       <RouterLink class="button-link" to="/super-admin/admins">Tenant Admins</RouterLink>
-      <RouterLink class="button-link" to="/super-admin/gear">All Gear</RouterLink>
+      <RouterLink class="button-link" to="/super-admin/gear">All Items</RouterLink>
       <RouterLink class="button-link" to="/super-admin/students">All Students</RouterLink>
       <RouterLink class="button-link" to="/super-admin/logs">All Logs</RouterLink>
       <RouterLink class="button-link" to="/super-admin/broadcasts">Broadcasts</RouterLink>

--- a/src/pages/tenant/Checkout.vue
+++ b/src/pages/tenant/Checkout.vue
@@ -46,11 +46,11 @@
             </li>
           </ul>
         </div>
-        <p v-else class="muted">No gear currently checked out.</p>
+        <p v-else class="muted">No items currently checked out.</p>
       </div>
       <div v-if="student">
         <label>
-          Gear barcode
+          Item barcode
           <div class="input-row">
             <input
               ref="barcodeField"

--- a/src/pages/tenant/admin/AdminHome.vue
+++ b/src/pages/tenant/admin/AdminHome.vue
@@ -17,7 +17,7 @@
         <p>Manage students and view checkout history.</p>
       </RouterLink>
       <RouterLink class="admin-card" to="/tenant/admin/logs">
-        <h2>Gear Logs</h2>
+        <h2>Item Logs</h2>
         <p>View checkout and return activity.</p>
       </RouterLink>
       <RouterLink class="admin-card" to="/tenant/admin/return">
@@ -35,6 +35,10 @@
       <RouterLink class="admin-card" to="/tenant/admin/item-status">
         <h2>Item Status Tracking</h2>
         <p>Track lost, damaged, repair statuses and overdue reminder settings.</p>
+      </RouterLink>
+      <RouterLink class="admin-card" to="/tenant/admin/gear-import">
+        <h2>Bulk Item Import</h2>
+        <p>Import items in bulk from CSV with preview and validation.</p>
       </RouterLink>
       <RouterLink class="admin-card" to="/tenant/admin/barcodes">
         <h2>Bulk Barcode Generator</h2>

--- a/src/pages/tenant/admin/GearImport.vue
+++ b/src/pages/tenant/admin/GearImport.vue
@@ -1,0 +1,314 @@
+<template>
+  <div class="page">
+    <div class="page-nav-left">
+      <RouterLink class="button-link" to="/tenant/admin">Return to admin panel</RouterLink>
+      <RouterLink class="button-link" to="/tenant/admin/gear">Return to items</RouterLink>
+    </div>
+
+    <h1>Bulk Item Import Wizard</h1>
+    <p>Paste CSV rows, preview parsed entries, then import items in one action.</p>
+
+    <div class="card">
+      <h2>Step 1: Paste CSV</h2>
+      <p class="muted">Format: <code>name,barcode,serial_number,notes</code>. Header row is optional. Status is set to <code>available</code> automatically.</p>
+      <div class="form-actions import-template-actions">
+        <button type="button" @click="downloadTemplate">Download Template CSV</button>
+      </div>
+      <label>
+        Import CSV file
+        <input type="file" accept=".csv,text/csv" @change="handleCsvFileSelect" />
+      </label>
+      <p class="muted">Selecting a CSV file will auto-fill the text box below.</p>
+      <textarea
+        v-model="rawInput"
+        rows="10"
+        placeholder="name,barcode,serial_number,notes&#10;Camera A,ITX-001,SN1001,Main checkout camera"
+      ></textarea>
+      <div class="form-actions">
+        <button type="button" class="button-primary" @click="parseRows">Parse rows</button>
+      </div>
+    </div>
+
+    <div class="card" v-if="parsedRows.length">
+      <h2>Step 2: Preview</h2>
+      <p class="muted">Ready: {{ parsedRows.length }} rows | Skipped in parse: {{ parseSkipped.length }}</p>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Barcode</th>
+            <th>Serial</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, index) in parsedRows.slice(0, 200)" :key="`${row.barcode}-${index}`">
+            <td>{{ row.name }}</td>
+            <td>{{ row.barcode }}</td>
+            <td>{{ row.serial_number || "-" }}</td>
+            <td>{{ row.notes || "-" }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-if="parsedRows.length > 200" class="muted">Showing first 200 rows in preview.</p>
+      <div class="form-actions">
+        <button type="button" class="button-primary" :disabled="isImporting" @click="runImport">
+          {{ isImporting ? "Importing..." : "Step 3: Import rows" }}
+        </button>
+      </div>
+    </div>
+
+    <div class="card" v-if="parseSkipped.length">
+      <h2>Parse Skipped Rows</h2>
+      <ul>
+        <li v-for="(item, index) in parseSkipped" :key="`parse-${index}`">
+          {{ item.barcode }} — {{ item.reason }}
+        </li>
+      </ul>
+      <div class="form-actions">
+        <button type="button" @click="downloadValidationReport('parse')">
+          Download Parse Validation Report
+        </button>
+      </div>
+    </div>
+
+    <div class="card" v-if="importResult">
+      <h2>Import Result</h2>
+      <p>
+        Inserted: <strong>{{ importResult.inserted }}</strong>
+        | Skipped: <strong>{{ importResult.skipped }}</strong>
+      </p>
+      <div v-if="importResult.skipped_rows.length">
+        <h3>Skipped Rows</h3>
+        <ul>
+          <li v-for="(item, index) in importResult.skipped_rows" :key="`skip-${index}`">
+            {{ item.barcode }} — {{ item.reason }}
+          </li>
+        </ul>
+        <div class="form-actions">
+          <button type="button" @click="downloadValidationReport('import')">
+            Download Import Validation Report
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <p v-if="error" class="error">{{ error }}</p>
+    <p v-if="success" class="success">{{ success }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { RouterLink } from "vue-router";
+import { bulkImportGear } from "../../../services/adminOpsService";
+import { logAdminAction } from "../../../services/auditLogService";
+import { enforceAdminRateLimit } from "../../../services/rateLimitService";
+
+type ImportRow = {
+  name: string;
+  barcode: string;
+  serial_number?: string;
+  status?: string;
+  notes?: string;
+};
+
+const rawInput = ref("");
+const parsedRows = ref<ImportRow[]>([]);
+const parseSkipped = ref<Array<{ barcode: string; reason: string }>>([]);
+const isImporting = ref(false);
+const error = ref("");
+const success = ref("");
+const importResult = ref<{
+  inserted: number;
+  skipped: number;
+  skipped_rows: Array<{ barcode: string; reason: string }>;
+} | null>(null);
+
+const toCsvCell = (value: string) => {
+  const escaped = value.replace(/"/g, "\"\"");
+  return `"${escaped}"`;
+};
+
+const downloadTextFile = (filename: string, content: string, contentType: string) => {
+  const blob = new Blob([content], { type: contentType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+const downloadTemplate = () => {
+  const csv = [
+    "name,barcode,serial_number,notes",
+    "Camera A,ITX-001,SN1001,Main checkout camera",
+    "Tripod B,ITX-002,SN1002,Studio item",
+  ].join("\n");
+  downloadTextFile("item-import-template.csv", csv, "text/csv;charset=utf-8");
+};
+
+const downloadValidationReport = (source: "parse" | "import") => {
+  const rows =
+    source === "parse"
+      ? parseSkipped.value
+      : (importResult.value?.skipped_rows ?? []);
+  if (!rows.length) {
+    error.value = "No validation rows to export.";
+    return;
+  }
+  const filename =
+    source === "parse"
+      ? `item-import-parse-validation-${new Date().toISOString().slice(0, 10)}.csv`
+      : `item-import-validation-${new Date().toISOString().slice(0, 10)}.csv`;
+  const csvRows = ["barcode,reason"];
+  for (const row of rows) {
+    csvRows.push(`${toCsvCell(row.barcode)},${toCsvCell(row.reason)}`);
+  }
+  downloadTextFile(filename, csvRows.join("\n"), "text/csv;charset=utf-8");
+};
+
+const parseLine = (line: string) => {
+  const parts: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (char === "," && !inQuotes) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current.trim());
+
+  return {
+    name: parts[0] ?? "",
+    barcode: parts[1] ?? "",
+    serial_number: parts[2] ?? "",
+    notes: parts.slice(3).join(",").trim(),
+  };
+};
+
+const parseRows = () => {
+  error.value = "";
+  success.value = "";
+  importResult.value = null;
+
+  const lines = rawInput.value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (!lines.length) {
+    error.value = "Paste at least one CSV row.";
+    parsedRows.value = [];
+    parseSkipped.value = [];
+    return;
+  }
+
+  const parsed: ImportRow[] = [];
+  const skipped: Array<{ barcode: string; reason: string }> = [];
+
+  const firstRow = parseLine(lines[0] ?? "");
+  const hasHeader =
+    firstRow.name.toLowerCase() === "name" && firstRow.barcode.toLowerCase() === "barcode";
+
+  for (const [index, line] of lines.entries()) {
+    if (index === 0 && hasHeader) {
+      continue;
+    }
+    const row = parseLine(line);
+    const name = row.name.trim();
+    const barcode = row.barcode.trim();
+    if (!name || !barcode) {
+      skipped.push({ barcode: barcode || "(blank)", reason: "Missing name or barcode." });
+      continue;
+    }
+    parsed.push({
+      name,
+      barcode,
+      serial_number: row.serial_number?.trim() || undefined,
+      notes: row.notes?.trim() || undefined,
+    });
+  }
+
+  parsedRows.value = parsed;
+  parseSkipped.value = skipped;
+
+  if (!parsed.length) {
+    error.value = "No valid rows found after parsing.";
+  }
+};
+
+const runImport = async () => {
+  if (!parsedRows.value.length) {
+    error.value = "Parse rows first.";
+    return;
+  }
+
+  isImporting.value = true;
+  error.value = "";
+  success.value = "";
+  importResult.value = null;
+
+  try {
+    await enforceAdminRateLimit();
+    const result = await bulkImportGear(parsedRows.value);
+    importResult.value = {
+      inserted: result.inserted,
+      skipped: result.skipped,
+      skipped_rows: result.skipped_rows,
+    };
+
+    await logAdminAction({
+      action_type: "gear_bulk_import",
+      entity_type: "gear",
+      metadata: {
+        inserted: result.inserted,
+        skipped: result.skipped,
+      },
+    });
+
+    success.value = `Import complete. Added ${result.inserted} items.`;
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : "Unable to import rows.";
+  } finally {
+    isImporting.value = false;
+  }
+};
+
+const handleCsvFileSelect = async (event: Event) => {
+  const input = event.target as HTMLInputElement | null;
+  const file = input?.files?.[0];
+  if (!file) {
+    return;
+  }
+  try {
+    rawInput.value = await file.text();
+    error.value = "";
+    success.value = "CSV loaded. Click \"Parse rows\" to preview.";
+  } catch {
+    error.value = "Unable to read CSV file.";
+  } finally {
+    if (input) {
+      input.value = "";
+    }
+  }
+};
+</script>
+
+<style scoped>
+.import-template-actions {
+  margin-bottom: 0.8rem;
+}
+</style>

--- a/src/pages/tenant/admin/ItemStatusTracking.vue
+++ b/src/pages/tenant/admin/ItemStatusTracking.vue
@@ -15,15 +15,60 @@
 
     <div class="card">
       <h2>Overdue reminder settings</h2>
-      <label>
-        Checkout due time limit (hours)
-        <input v-model.number="dueHours" type="number" min="1" max="720" />
-      </label>
-      <p class="muted">Reminders are sent for checked_out items older than this limit.</p>
+      <div class="form-grid-2">
+        <label>
+          Checkout due time limit (hours)
+          <input v-model.number="dueHours" type="number" min="1" max="720" />
+        </label>
+        <label>
+          Escalation level 1 (hours)
+          <input v-model.number="escalationLevel1" type="number" min="1" max="720" />
+        </label>
+        <label>
+          Escalation level 2 (hours)
+          <input v-model.number="escalationLevel2" type="number" min="1" max="720" />
+        </label>
+        <label>
+          Escalation level 3 (hours)
+          <input v-model.number="escalationLevel3" type="number" min="1" max="720" />
+        </label>
+      </div>
+      <p class="muted">
+        Reminders are sent for checked_out items older than due limit. Escalation levels control notice severity.
+      </p>
     </div>
 
     <div class="card">
       <h2>Current flagged items</h2>
+      <div class="form-grid-2">
+        <label>
+          Search
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="Search by item name, barcode, status, or note"
+          />
+        </label>
+        <label>
+          Status
+          <select v-model="statusFilter">
+            <option value="all">all statuses</option>
+            <option value="damaged">damaged</option>
+            <option value="lost">lost</option>
+            <option value="in_repair">in_repair</option>
+            <option value="retired">retired</option>
+            <option value="in_studio_only">in_studio_only</option>
+          </select>
+        </label>
+        <label>
+          From
+          <input v-model="dateFrom" type="date" />
+        </label>
+        <label>
+          To
+          <input v-model="dateTo" type="date" />
+        </label>
+      </div>
       <p v-if="isLoading" class="muted">Loading status tracking...</p>
       <table v-else class="table">
         <thead>
@@ -36,14 +81,14 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="item in flaggedItems" :key="item.id">
+          <tr v-for="item in filteredFlaggedItems" :key="item.id">
             <td>{{ item.name }}</td>
             <td>{{ item.barcode }}</td>
             <td>{{ item.status }}</td>
             <td>{{ formatDate(item.updated_at) }}</td>
             <td>{{ item.notes || "-" }}</td>
           </tr>
-          <tr v-if="flaggedItems.length === 0">
+          <tr v-if="filteredFlaggedItems.length === 0">
             <td colspan="5" class="muted">No flagged items.</td>
           </tr>
         </tbody>
@@ -66,13 +111,13 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="event in history" :key="event.id">
+          <tr v-for="event in filteredHistory" :key="event.id">
             <td>{{ formatDate(event.changed_at) }}</td>
             <td>{{ event.gear?.name || "-" }} ({{ event.gear?.barcode || "-" }})</td>
             <td>{{ event.status }}</td>
             <td>{{ event.note || "-" }}</td>
           </tr>
-          <tr v-if="history.length === 0">
+          <tr v-if="filteredHistory.length === 0">
             <td colspan="4" class="muted">No status history found.</td>
           </tr>
         </tbody>
@@ -91,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 import {
   fetchStatusTracking,
@@ -103,13 +148,56 @@ import {
 import { exportRowsToCsv, exportRowsToPdf } from "../../../services/exportService";
 
 const dueHours = ref(72);
+const escalationLevel1 = ref(120);
+const escalationLevel2 = ref(168);
+const escalationLevel3 = ref(240);
 const flaggedItems = ref<StatusTrackedItem[]>([]);
 const history = ref<StatusHistoryItem[]>([]);
 const isLoading = ref(false);
 const isSaving = ref(false);
 const toastTitle = ref("");
 const toastMessage = ref("");
+const searchQuery = ref("");
+const statusFilter = ref("all");
+const dateFrom = ref("");
+const dateTo = ref("");
 let toastTimer: number | null = null;
+
+const withinDateRange = (value: string) => {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return true;
+  if (dateFrom.value) {
+    const fromTs = Date.parse(`${dateFrom.value}T00:00:00`);
+    if (!Number.isNaN(fromTs) && timestamp < fromTs) return false;
+  }
+  if (dateTo.value) {
+    const toTs = Date.parse(`${dateTo.value}T23:59:59`);
+    if (!Number.isNaN(toTs) && timestamp > toTs) return false;
+  }
+  return true;
+};
+
+const filteredFlaggedItems = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase();
+  return flaggedItems.value.filter((item) => {
+    if (statusFilter.value !== "all" && item.status !== statusFilter.value) return false;
+    if (!withinDateRange(item.updated_at)) return false;
+    if (!query) return true;
+    const haystack = `${item.name} ${item.barcode} ${item.status} ${item.notes ?? ""}`.toLowerCase();
+    return haystack.includes(query);
+  });
+});
+
+const filteredHistory = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase();
+  return history.value.filter((event) => {
+    if (statusFilter.value !== "all" && event.status !== statusFilter.value) return false;
+    if (!withinDateRange(event.changed_at)) return false;
+    if (!query) return true;
+    const haystack = `${event.gear?.name ?? ""} ${event.gear?.barcode ?? ""} ${event.status} ${event.note ?? ""}`.toLowerCase();
+    return haystack.includes(query);
+  });
+});
 
 const showToast = (title: string, message: string) => {
   toastTitle.value = title;
@@ -130,11 +218,21 @@ const formatDate = (value: string) => {
   return date.toLocaleString();
 };
 
+const normalizeEscalations = () => {
+  dueHours.value = Math.max(1, Math.floor(Number(dueHours.value) || 72));
+  escalationLevel1.value = Math.max(dueHours.value, Math.floor(Number(escalationLevel1.value) || 120));
+  escalationLevel2.value = Math.max(escalationLevel1.value + 1, Math.floor(Number(escalationLevel2.value) || 168));
+  escalationLevel3.value = Math.max(escalationLevel2.value + 1, Math.floor(Number(escalationLevel3.value) || 240));
+};
+
 const loadStatusTracking = async () => {
   isLoading.value = true;
   try {
     const payload = await fetchStatusTracking();
     dueHours.value = payload.due_hours;
+    escalationLevel1.value = payload.escalation_level_1_hours;
+    escalationLevel2.value = payload.escalation_level_2_hours;
+    escalationLevel3.value = payload.escalation_level_3_hours;
     flaggedItems.value = payload.flagged_items;
     history.value = payload.history;
   } catch (err) {
@@ -146,9 +244,15 @@ const loadStatusTracking = async () => {
 
 const saveDueLimit = async () => {
   isSaving.value = true;
+  normalizeEscalations();
   try {
-    await saveDuePolicy(dueHours.value);
-    showToast("Saved", "Due time limit updated.");
+    await saveDuePolicy(
+      dueHours.value,
+      escalationLevel1.value,
+      escalationLevel2.value,
+      escalationLevel3.value
+    );
+    showToast("Saved", "Due time and escalation levels updated.");
   } catch (err) {
     showToast("Save failed", err instanceof Error ? err.message : "Unable to save due time limit.");
   } finally {
@@ -172,7 +276,7 @@ const exportFlaggedCsv = () => {
   exportRowsToCsv(
     `item-status-${new Date().toISOString().slice(0, 10)}.csv`,
     ["name", "barcode", "status", "updated_at", "notes"],
-    flaggedItems.value
+    filteredFlaggedItems.value
   );
 };
 
@@ -181,7 +285,7 @@ const exportFlaggedPdf = () => {
     `item-status-${new Date().toISOString().slice(0, 10)}.pdf`,
     "Item Status Tracking",
     ["name", "barcode", "status", "updated_at", "notes"],
-    flaggedItems.value
+    filteredFlaggedItems.value
   );
 };
 
@@ -189,7 +293,7 @@ const exportHistoryCsv = () => {
   exportRowsToCsv(
     `item-status-history-${new Date().toISOString().slice(0, 10)}.csv`,
     ["changed_at", "item", "barcode", "status", "note"],
-    history.value.map((event) => ({
+    filteredHistory.value.map((event) => ({
       changed_at: formatDate(event.changed_at),
       item: event.gear?.name || "",
       barcode: event.gear?.barcode || "",
@@ -204,7 +308,7 @@ const exportHistoryPdf = () => {
     `item-status-history-${new Date().toISOString().slice(0, 10)}.pdf`,
     "Item Status History",
     ["changed_at", "item", "barcode", "status", "note"],
-    history.value.map((event) => ({
+    filteredHistory.value.map((event) => ({
       changed_at: formatDate(event.changed_at),
       item: event.gear?.name || "",
       barcode: event.gear?.barcode || "",

--- a/src/pages/tenant/admin/QuickReturn.vue
+++ b/src/pages/tenant/admin/QuickReturn.vue
@@ -8,7 +8,7 @@
 
     <div class="card">
       <label>
-        Gear barcode
+        Item barcode
         <div class="input-row">
           <input
             ref="barcodeField"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -142,6 +142,18 @@ const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "/tenant/admin/gear-import",
+    name: "tenant-admin-gear-import",
+    component: () => import("../pages/tenant/admin/GearImport.vue"),
+    meta: {
+      requiresSession: true,
+      requiresTenant: true,
+      requiresRole: "tenant_admin",
+      requiresTenantMatch: true,
+    },
+  },
+
+  {
     path: "/super-auth",
     name: "super-auth",
     component: () => import("../pages/super/SuperAuth.vue"),

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -56,6 +56,7 @@ export const fetchGearByBarcode = async (barcode: string) => {
       .from("gear")
       .select("id, name, barcode, status")
       .eq("barcode", barcode)
+      .is("deleted_at", null)
       .single(),
     LOOKUP_TIMEOUT_MS,
     "Barcode lookup timed out."
@@ -74,6 +75,7 @@ export const fetchStudentByStudentId = async (studentId: string) => {
       .from("students")
       .select("id, first_name, last_name, student_id")
       .eq("student_id", studentId)
+      .is("deleted_at", null)
       .single(),
     LOOKUP_TIMEOUT_MS,
     "Student lookup timed out."
@@ -91,13 +93,14 @@ export const fetchCheckedOutGear = async (studentUuid: string) => {
     supabase
       .from("gear")
       .select("id, name, barcode, status")
-      .eq("checked_out_by", studentUuid),
+      .eq("checked_out_by", studentUuid)
+      .is("deleted_at", null),
     LOOKUP_TIMEOUT_MS,
-    "Checked out gear lookup timed out."
+    "Checked out items lookup timed out."
   );
 
   if (error) {
-    throw new Error("Unable to load gear.");
+    throw new Error("Unable to load items.");
   }
 
   return (data ?? []) as GearSummary[];

--- a/src/services/superGearService.ts
+++ b/src/services/superGearService.ts
@@ -36,7 +36,7 @@ const callSuperGear = async <TData>(payload: SuperGearRequest) => {
   );
 
   if (!result.ok) {
-    throw new Error(result.error || "Super gear request failed.");
+    throw new Error(result.error || "Super item request failed.");
   }
 
   return result.data?.data as TData;

--- a/src/style.css
+++ b/src/style.css
@@ -286,6 +286,12 @@ textarea {
   margin-top: 1.1rem;
 }
 
+.form-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.8rem 1rem;
+}
+
 .form-help-row {
   display: flex;
   justify-content: space-between;

--- a/supabase/functions/checkoutReturn/index.ts
+++ b/supabase/functions/checkoutReturn/index.ts
@@ -174,6 +174,7 @@ serve(async (req) => {
         .select("id, tenant_id")
         .eq("student_id", student_id.trim())
         .eq("tenant_id", callerProfile.tenant_id)
+        .is("deleted_at", null)
         .single();
 
       if (studentError || !studentData?.id || !studentData.tenant_id) {
@@ -195,6 +196,7 @@ serve(async (req) => {
         .select("id, tenant_id, checked_out_by")
         .eq("barcode", barcode)
         .eq("tenant_id", callerProfile.tenant_id)
+        .is("deleted_at", null)
         .single();
 
       if (!gear) continue;

--- a/supabase/functions/super-gear-mutate/index.ts
+++ b/supabase/functions/super-gear-mutate/index.ts
@@ -167,7 +167,7 @@ serve(async (req) => {
 
       const { data, error } = await query;
       if (error) {
-        return jsonResponse(400, { error: "Unable to load gear." });
+        return jsonResponse(400, { error: "Unable to load items." });
       }
       return jsonResponse(200, { data: data ?? [] });
     }
@@ -199,7 +199,7 @@ serve(async (req) => {
         .single();
 
       if (error || !data) {
-        return jsonResponse(400, { error: "Unable to create gear." });
+        return jsonResponse(400, { error: "Unable to create item." });
       }
       return jsonResponse(200, { data });
     }
@@ -250,7 +250,7 @@ serve(async (req) => {
         .single();
 
       if (error || !data) {
-        return jsonResponse(400, { error: "Unable to update gear." });
+        return jsonResponse(400, { error: "Unable to update item." });
       }
       return jsonResponse(200, { data });
     }
@@ -263,7 +263,7 @@ serve(async (req) => {
 
       if (!id || !password || phrase.trim() !== "CONFIRM") {
         return jsonResponse(400, {
-          error: "Super password and confirmation are required to delete gear.",
+          error: "Super password and confirmation are required to delete item.",
         });
       }
 
@@ -279,7 +279,7 @@ serve(async (req) => {
 
       const { error } = await adminClient.from("gear").delete().eq("id", id);
       if (error) {
-        return jsonResponse(400, { error: "Unable to delete gear." });
+        return jsonResponse(400, { error: "Unable to delete item." });
       }
       return jsonResponse(200, { data: { success: true } });
     }

--- a/supabase/sql/super_admin_setup.sql
+++ b/supabase/sql/super_admin_setup.sql
@@ -133,3 +133,32 @@ create table if not exists public.gear_status_history (
 
 create index if not exists idx_gear_status_history_tenant_changed_at
   on public.gear_status_history (tenant_id, changed_at desc);
+
+-- Soft delete support for tenant gear/students
+alter table if exists public.gear
+  add column if not exists deleted_at timestamptz;
+
+alter table if exists public.gear
+  add column if not exists deleted_by uuid references auth.users(id) on delete set null;
+
+alter table if exists public.students
+  add column if not exists deleted_at timestamptz;
+
+alter table if exists public.students
+  add column if not exists deleted_by uuid references auth.users(id) on delete set null;
+
+create index if not exists idx_gear_tenant_deleted_at
+  on public.gear (tenant_id, deleted_at);
+
+create index if not exists idx_students_tenant_deleted_at
+  on public.students (tenant_id, deleted_at);
+
+-- Escalation thresholds for overdue reminders
+alter table if exists public.tenant_policies
+  add column if not exists escalation_level_1_hours int not null default 120;
+
+alter table if exists public.tenant_policies
+  add column if not exists escalation_level_2_hours int not null default 168;
+
+alter table if exists public.tenant_policies
+  add column if not exists escalation_level_3_hours int not null default 240;


### PR DESCRIPTION
Added Bulk Item Import Wizard page and routing at /tenant/admin/gear-import, including CSV paste flow, CSV file upload option, template CSV download, parse preview, import execution, and downloadable parse/import validation reports.\n- Extended admin-ops bulk_import_gear support and connected frontend service calls for import execution and skipped-row reporting.\n- Added overdue escalation policy handling (due + escalation levels) across admin status tracking UI and admin-ops payloads.\n- Implemented soft-delete and restore workflows for tenant items and students: edge functions now support list_deleted/restore and archive behavior; frontend pages now show archived tables with restore actions; checkout and lookup paths now exclude soft-deleted rows.\n- Added advanced filtering across key screens: tenant item management (search + status), students (search for active/archived), item logs (search + action + date range), item status tracking (search + status + date range), and super item list (status filter).\n- Implemented tenant-admin idle auto logout in App shell for /tenant/admin* routes (except /tenant/admin-login), with activity listeners and configurable timeout via VITE_ADMIN_IDLE_TIMEOUT_MINUTES (default 20).\n- Updated broad user-facing terminology from gear to item/items in tenant/super UI labels, exports, toasts, and related frontend/backend message strings to support non-gear inventory use cases.\n- Added supporting schema updates in super_admin_setup.sql for soft delete fields and escalation policy columns.