### PR TITLE
fix(internal): remove super-admin back link, simplify auth page styling, and allow internal subdomain CORS

### DIFF
--- a/cloudflare/edge-proxy/src/index.ts
+++ b/cloudflare/edge-proxy/src/index.ts
@@ -11,6 +11,11 @@ const BASE_CORS_HEADERS = {
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   Vary: "Origin",
 };
+const DEFAULT_ALLOWED_ORIGINS = [
+  "https://itemtraxx.com",
+  "https://www.itemtraxx.com",
+  "https://internal.itemtraxx.com",
+];
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 
@@ -71,7 +76,9 @@ export default {
     const requestId =
       request.headers.get("x-request-id") ??
       (typeof crypto?.randomUUID === "function" ? crypto.randomUUID() : "itx-edge-request");
-    const allowedOrigins = parseCsv(env.ALLOWED_ORIGINS);
+    const allowedOrigins = Array.from(
+      new Set([...DEFAULT_ALLOWED_ORIGINS, ...parseCsv(env.ALLOWED_ORIGINS)])
+    );
     const { originAllowed, headers } = withCorsHeaders(origin, allowedOrigins);
 
     if (request.method === "OPTIONS") {

--- a/cloudflare/edge-proxy/wrangler.toml
+++ b/cloudflare/edge-proxy/wrangler.toml
@@ -4,6 +4,6 @@ compatibility_date = "2026-02-11"
 
 [vars]
 # Comma-separated origins allowed to call this proxy.
-ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,http://localhost:5173,http://localhost:5174,http://192.168.1.22:5173"
+ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://internal.itemtraxx.com,http://localhost:5173,http://localhost:5174,http://192.168.1.22:5173"
 # Optional hard allowlist of function names (comma-separated).
 ALLOWED_FUNCTIONS = "tenant-login,checkoutReturn,create-tenant-admin,admin-gear-mutate,admin-student-mutate,admin-ops,system-status,super-tenant-mutate,super-admin-mutate,super-dashboard,super-gear-mutate,super-student-mutate,super-logs-query,super-ops,contact-sales-submit,job-worker"

--- a/src/pages/internal/InternalAuth.vue
+++ b/src/pages/internal/InternalAuth.vue
@@ -145,7 +145,7 @@ onUnmounted(() => {
   min-height: 100vh;
   margin: -2.5rem -2rem -3rem;
   padding: 2.4rem 0 3rem;
-  background: linear-gradient(180deg, #1f4ca3 0%, #2f79c8 48%, #38d0b1 100%);
+  background: transparent;
 }
 
 .internal-auth-page {

--- a/src/pages/internal/InternalOps.vue
+++ b/src/pages/internal/InternalOps.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="page">
     <div class="page-nav-left">
-      <RouterLink class="button-link" to="/super-admin">Back to Super Admin</RouterLink>
       <button type="button" @click="loadSnapshot(true)" :disabled="isLoading">
         {{ isLoading ? "Refreshing..." : "Refresh now" }}
       </button>
@@ -99,7 +98,6 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
-import { RouterLink } from "vue-router";
 import { getInternalOpsSnapshot, type InternalOpsSnapshot } from "../../services/superOpsService";
 
 const snapshot = ref<InternalOpsSnapshot | null>(null);


### PR DESCRIPTION

- Remove the "Back to Super Admin" navigation button from InternalOps UI\n- Remove gradient background from InternalAuth shell to use the standard app background\n- Add https://internal.itemtraxx.com to edge proxy ALLOWED_ORIGINS in wrangler vars\n- Add built-in first-party origin defaults in proxy runtime (itemtraxx.com, www, internal) to prevent misconfigured env allowlists from breaking internal ops requests\n- Preserve existing explicit ALLOWED_ORIGINS entries and dedupe at runtime\n\nThis resolves blocked preflight/fetch calls from internal.itemtraxx.com to super-ops/system-status through the edge proxy.