### PR TITLE
fix(internal): refresh session token before super-ops calls to prevent invalid JWT

### DIFF
--- a/src/services/superOpsService.ts
+++ b/src/services/superOpsService.ts
@@ -192,6 +192,13 @@ type SuperOpsRequest = {
 };
 
 const getAccessToken = async () => {
+  // Force a token refresh first so super-admin/internal flows do not send stale JWTs.
+  const refreshed = await supabase.auth.refreshSession();
+  const refreshedToken = refreshed.data.session?.access_token;
+  if (!refreshed.error && refreshedToken) {
+    return refreshedToken;
+  }
+
   const { data, error } = await supabase.auth.getSession();
   if (error || !data.session?.access_token) {
     throw new Error("Unauthorized");


### PR DESCRIPTION
Update superOpsService access token retrieval to call supabase.auth.refreshSession() first\n- Fallback to current session token when refresh is unavailable\n- Prevent intermittent 401 Invalid JWT errors on internal dashboard snapshots caused by stale access tokens