### PR TITLE
fix(auth): retry edge function calls on any 401 after session refresh

### DIFF
--- a/src/services/edgeFunctionClient.ts
+++ b/src/services/edgeFunctionClient.ts
@@ -180,12 +180,9 @@ export const invokeEdgeFunction = async <TData = unknown, TBody = unknown>(
     return requestEdgeFunction<TData, TBody>(functionName, options);
   }
 
-  if (
-    first.status === 401 &&
-    isInvalidJwtError({ error: first.error }) &&
-    options.accessToken
-  ) {
+  if (first.status === 401 && options.accessToken) {
     // Retry once with a freshly refreshed session token.
+    // Some upstream paths return generic 401 "Unauthorized" instead of "Invalid JWT".
     const { data, error } = await supabase.auth.refreshSession();
     const refreshedToken = data.session?.access_token;
     if (!error && refreshedToken) {


### PR DESCRIPTION
- Update edgeFunctionClient retry policy to refresh Supabase session and retry once for any 401 response when an access token is present\n- Remove dependency on specific error text (e.g. "Invalid JWT") so generic "Unauthorized" responses also recover\n- Addresses intermittent 401 failures for internal super-ops requests where token is valid but upstream auth check races return generic 401