### PR TITLE
fix(super-ops): fallback to SUPABASE_* env vars for auth client initialization

### DIFF
--- a/supabase/functions/super-ops/index.ts
+++ b/supabase/functions/super-ops/index.ts
@@ -58,9 +58,13 @@ serve(async (req) => {
       return jsonResponse(401, { error: "Unauthorized" });
     }
 
-    const supabaseUrl = Deno.env.get("ITX_SUPABASE_URL");
-    const publishableKey = Deno.env.get("ITX_PUBLISHABLE_KEY");
-    const serviceKey = Deno.env.get("ITX_SECRET_KEY");
+    // Prefer ITX_* secrets, but fall back to Supabase default injected env vars.
+    const supabaseUrl =
+      Deno.env.get("ITX_SUPABASE_URL") ?? Deno.env.get("SUPABASE_URL");
+    const publishableKey =
+      Deno.env.get("ITX_PUBLISHABLE_KEY") ?? Deno.env.get("SUPABASE_ANON_KEY");
+    const serviceKey =
+      Deno.env.get("ITX_SECRET_KEY") ?? Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
     if (!supabaseUrl || !publishableKey || !serviceKey) {
       return jsonResponse(500, { error: "Server misconfiguration" });


### PR DESCRIPTION


- Add env fallbacks in super-ops to use SUPABASE_URL, SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY when ITX_* vars are missing or mismatched\n- Prevent auth verification mismatches that can surface as 401 Unauthorized/Invalid JWT even with valid client tokens\n- Keeps existing ITX_* env support intact while improving runtime resilience across environments