### PR TITLE
fix(internal-auth): stabilize super-ops auth validation and remove direct CORS-failing fallback

### DIFF
--- a/src/services/edgeFunctionClient.ts
+++ b/src/services/edgeFunctionClient.ts
@@ -188,27 +188,5 @@ export const invokeEdgeFunction = async <TData = unknown, TBody = unknown>(
     }
   }
 
-  // If proxy still rejects super-admin calls after refresh, retry direct Supabase endpoint once.
-  // This isolates worker header/forwarding mismatches without breaking tenant/admin flows.
-  const usingProxy = !!(import.meta.env.VITE_EDGE_PROXY_URL as string | undefined)?.trim();
-  if (
-    usingProxy &&
-    functionName.startsWith("super-") &&
-    current.status === 401
-  ) {
-    const directBaseUrl = getDirectFunctionsBaseUrl();
-    if (directBaseUrl) {
-      const refreshed = await supabase.auth.refreshSession();
-      const fallbackToken =
-        refreshed.data.session?.access_token ?? options.accessToken;
-      return requestEdgeFunction<TData, TBody>(
-        functionName,
-        options,
-        fallbackToken,
-        directBaseUrl
-      );
-    }
-  }
-
   return current;
 };


### PR DESCRIPTION


- super-ops: validate bearer token with service-role client via auth.getUser(token)\n- super-ops: remove dependency on publishable-key user client for JWT verification\n- super-ops: keep fallback env support for SUPABASE_* secrets\n- edgeFunctionClient: remove browser direct-to-Supabase fallback for super-* calls (caused CORS preflight failures on internal domain)\n- edgeFunctionClient: keep 401 refresh-and-retry behavior through proxy\n\nThis targets internal.itemtraxx.com super-ops 401/Invalid JWT failures while eliminating secondary CORS errors from direct function fallback.