### PR TITLE
fix(internal-super-ops): bypass gateway JWT mismatch by forwarding user token via custom header

### DIFF
--- a/supabase/functions/super-ops/index.ts
+++ b/supabase/functions/super-ops/index.ts
@@ -53,7 +53,8 @@ serve(async (req) => {
   }
 
   try {
-    const authHeader = req.headers.get("authorization");
+    const authHeader =
+      req.headers.get("x-itx-user-jwt") ?? req.headers.get("authorization");
     if (!authHeader) {
       return jsonResponse(401, { error: "Unauthorized" });
     }


### PR DESCRIPTION


- edge proxy: for super-ops only, forward browser Authorization token as x-itx-user-jwt and send anon Authorization upstream\n- super-ops: read x-itx-user-jwt first, then authorization fallback\n- super-ops: keep service-role token verification via auth.getUser(token)\n\nThis avoids upstream gateway-level Invalid JWT rejection while preserving explicit token verification inside super-ops.