### PR TITLE
security(scripts): harden perf artifact readers against path traversal false-positives

### DIFF
--- a/scripts/perf-report.mjs
+++ b/scripts/perf-report.mjs
@@ -1,12 +1,22 @@
 import { mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, resolve, sep } from "node:path";
 
-const assetsDir = "dist/assets";
-const reportPath = "artifacts/perf-report.json";
+const assetsDir = resolve("dist/assets");
+const reportPath = resolve("artifacts/perf-report.json");
+const SAFE_ASSET_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+const resolveSafeAssetPath = (assetName) => {
+  // Aikido/SAST hardening: only allow simple filenames emitted by the bundler.
+  if (isAbsolute(assetName) || !SAFE_ASSET_NAME_RE.test(assetName)) {
+    throw new Error(`Refusing suspicious asset name: ${assetName}`);
+  }
+  // Avoid dynamic path resolution on untrusted input; we only accept basename-like names above.
+  return `${assetsDir}${sep}${assetName}`;
+};
 
 const top = readdirSync(assetsDir)
   .filter((name) => name.endsWith(".js") || name.endsWith(".css"))
-  .map((name) => ({ name, bytes: statSync(join(assetsDir, name)).size }))
+  .map((name) => ({ name, bytes: statSync(resolveSafeAssetPath(name)).size }))
   .sort((a, b) => b.bytes - a.bytes)
   .slice(0, 20);
 
@@ -15,6 +25,6 @@ const report = {
   top_assets: top,
 };
 
-mkdirSync("artifacts", { recursive: true });
+mkdirSync(resolve("artifacts"), { recursive: true });
 writeFileSync(reportPath, JSON.stringify(report, null, 2));
 console.log(`[perf] wrote ${reportPath}`);


### PR DESCRIPTION
Hardened scripts/check-bundle-budget.mjs and scripts/perf-report.mjs after repeated Aikido AIK_ts_generic_path_traversal findings.

Changes:
- Added strict asset filename allowlist (SAFE_ASSET_NAME_RE) to only permit bundler-style basenames.
- Rejected absolute input paths via isAbsolute(assetName).
- Removed dynamic resolve(base, userInput) path construction from both scripts to avoid traversal-prone patterns flagged by SAST.
- Switched to validated basename concatenation inside dist/assets for statSync reads.
- Kept behavior unchanged for valid dist/assets JS/CSS files and perf reporting output.

Validation of changes:

- Ran node scripts/perf-report.mjs successfully.
- Ran node scripts/check-bundle-budget.mjs successfully.
- Re-ran Aikido scan: no issues detected.