### PR TITLE
fix(ops): stabilize async worker auth and public status function access

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -264,6 +264,22 @@ max_frequency = "5s"
 # Keep gateway JWT verification off so proxy/header variations do not block valid requests.
 verify_jwt = false
 
+[functions.system-status]
+# Public health endpoint consumed by app shell before user auth.
+verify_jwt = false
+
+[functions.tenant-login]
+# Pre-auth login resolver (access code + turnstile); no JWT available yet.
+verify_jwt = false
+
+[functions.contact-sales-submit]
+# Public contact form endpoint with turnstile/rate-limit controls.
+verify_jwt = false
+
+[functions.job-worker]
+# Uses ITX_JOB_WORKER_SECRET header auth, not Supabase JWT auth.
+verify_jwt = false
+
 # This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
 # [auth.hook.custom_access_token]
 # enabled = true


### PR DESCRIPTION
- make job-worker Authorization validation tolerant to both raw token and Bearer token formats to prevent secret formatting mismatches in GitHub Actions
- configure system-status/tenant-login/contact-sales-submit/job-worker as verify_jwt=false in Supabase config because they are public or custom-auth endpoints
- aligns runtime behavior with existing function-level auth controls and prevents false degraded status from gateway 401 on system-status