### PR TITLE
fix(changelog): preserve file structure and use Pacific-time dating in auto-updates

### DIFF
--- a/.github/workflows/changelog-auto-update.yml
+++ b/.github/workflows/changelog-auto-update.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_SHA: ${{ github.sha }}
+          CHANGELOG_TIMEZONE: America/Los_Angeles
         run: node ./scripts/update-changelog-from-commits.mjs
 
       - name: Commit and push CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-Last updated: 2026-02-27 (year-month-day)
+Last updated (year-month-day): 2026-03-01
 
 All notable changes to **ItemTraxx** will be documented in this file. This includes new features, improvements, bug fixes, and other updates.
 
-This project adheres to **Semantic Versioning** where possible.
+Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
 
@@ -248,12 +248,6 @@ This project adheres to **Semantic Versioning** where possible.
 
 ---
 
-##### You have reached the bottom of the changelog.
----
-
-**© 2026 ItemTraxx Co. All rights reserved.**
-All changes documented here are subject to company internal guidelines and versioning standards.
-
 ### 2/28/2026 Development Update
 
 - feat: automate changelog updates and improve last updated formatting in documents.
@@ -268,3 +262,9 @@ All changes documented here are subject to company internal guidelines and versi
 - deps(deps-dev): bump @types/node in the npm-and-yarn group.
 
 ---
+
+##### You have reached the bottom of the changelog.
+---
+
+**© 2026 ItemTraxx Co. All rights reserved.**
+All changes documented here are subject to company internal guidelines and versioning standards.

--- a/scripts/update-changelog-from-commits.mjs
+++ b/scripts/update-changelog-from-commits.mjs
@@ -4,18 +4,38 @@ import { readFileSync, writeFileSync } from 'node:fs';
 const changelogPath = 'CHANGELOG.md';
 const before = process.env.GITHUB_EVENT_BEFORE || process.env.BEFORE_SHA;
 const after = process.env.GITHUB_SHA || process.env.AFTER_SHA;
+const changelogTimeZone = process.env.CHANGELOG_TIMEZONE || 'America/Los_Angeles';
 
 if (!before || !after) {
   console.log('Missing commit range; set GITHUB_EVENT_BEFORE/BEFORE_SHA and GITHUB_SHA/AFTER_SHA.');
   process.exit(0);
 }
 
-const formatDateForHeading = (d) => `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
-const formatDateIso = (d) => {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
+const getZonedDateParts = (d, timeZone) => {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.formatToParts(d);
+  const lookup = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  const year = Number(lookup.year);
+  const month = Number(lookup.month);
+  const day = Number(lookup.day);
+  return { year, month, day };
+};
+
+const formatDateForHeading = (d, timeZone) => {
+  const { year, month, day } = getZonedDateParts(d, timeZone);
+  return `${month}/${day}/${year}`;
+};
+
+const formatDateIso = (d, timeZone) => {
+  const { year, month, day } = getZonedDateParts(d, timeZone);
+  const m = String(month).padStart(2, '0');
+  const dd = String(day).padStart(2, '0');
+  return `${year}-${m}-${dd}`;
 };
 
 const getCommitSubjects = () => {
@@ -39,8 +59,21 @@ const getCommitSubjects = () => {
     .map((line) => line.endsWith('.') ? line : `${line}.`);
 };
 
-const upsertLastUpdated = (content, isoDate) =>
-  content.replace(/Last updated \(year-month-day\):\s*\d{4}-\d{2}-\d{2}/, `Last updated (year-month-day): ${isoDate}`);
+const upsertLastUpdated = (content, isoDate) => {
+  if (/Last updated \(year-month-day\):\s*\d{4}-\d{2}-\d{2}/.test(content)) {
+    return content.replace(
+      /Last updated \(year-month-day\):\s*\d{4}-\d{2}-\d{2}/,
+      `Last updated (year-month-day): ${isoDate}`
+    );
+  }
+  if (/Last updated:\s*\d{4}-\d{2}-\d{2}\s*\(year-month-day\)/.test(content)) {
+    return content.replace(
+      /Last updated:\s*\d{4}-\d{2}-\d{2}\s*\(year-month-day\)/,
+      `Last updated (year-month-day): ${isoDate}`
+    );
+  }
+  return content;
+};
 
 const insertIntoExistingSection = (content, heading, bullets) => {
   const headingIdx = content.indexOf(heading);
@@ -64,9 +97,17 @@ const insertIntoExistingSection = (content, heading, bullets) => {
   return `${content.slice(0, nextDividerIdx)}${insertion}${content.slice(nextDividerIdx)}`;
 };
 
+const FOOTER_MARKER = '##### You have reached the bottom of the changelog.';
+
 const appendNewSection = (content, heading, bullets) => {
   const section = `\n### ${heading}\n\n${bullets.map((b) => `- ${b}`).join('\n')}\n\n---\n`;
-  return `${content.trimEnd()}\n${section}`;
+  const footerIdx = content.indexOf(FOOTER_MARKER);
+  if (footerIdx === -1) {
+    return `${content.trimEnd()}\n${section}`;
+  }
+  const beforeFooter = content.slice(0, footerIdx).replace(/\s*$/, '\n\n');
+  const footerAndAfter = content.slice(footerIdx);
+  return `${beforeFooter}${section}\n${footerAndAfter}`;
 };
 
 const main = () => {
@@ -77,8 +118,8 @@ const main = () => {
   }
 
   const now = new Date();
-  const heading = `${formatDateForHeading(now)} Development Update`;
-  const isoDate = formatDateIso(now);
+  const heading = `${formatDateForHeading(now, changelogTimeZone)} Development Update`;
+  const isoDate = formatDateIso(now, changelogTimeZone);
 
   let content = readFileSync(changelogPath, 'utf8');
   content = upsertLastUpdated(content, isoDate);


### PR DESCRIPTION
- fix changelog auto-update insertion logic to append new daily sections before the footer marker instead of after the copyright block
- normalize Last updated handling so the updater supports both historical header formats and writes canonical `Last updated (year-month-day): YYYY-MM-DD`
- add timezone-aware date generation using Intl.DateTimeFormat to avoid UTC date drift in GitHub Actions
- configure workflow to pass `CHANGELOG_TIMEZONE=America/Los_Angeles` so changelog dates match Pacific time (PST/PDT)
- repair existing CHANGELOG.md structure by moving recent auto-generated entries above the footer and restoring footer-at-end layout