### PR TITLE
feat(platform): finish individual-plan admin support and cleanup pass

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
       href="%VITE_LOGO_URL%"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#090d14" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>ItemTraxx | Inventory Tracking System</title>
     <meta
       name="description"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="app-shell" :class="{ 'with-top-banners': hasTopBanners, 'route-shell-auth': isFullBleedRoute }" :style="appShellStyle">
+  <div
+    class="app-shell"
+    :class="{
+      'with-top-banners': hasTopBanners,
+      'route-shell-auth': isFullBleedRoute,
+      'route-shell-marketing': isMarketingFullBleedRoute,
+    }"
+    :style="appShellStyle"
+  >
     <div v-if="isRouteNavigating" class="route-progress" aria-hidden="true"></div>
     <div
       v-if="showMaintenanceBanner"
@@ -323,6 +331,12 @@ const isFullBleedRoute = computed(
     route.path === "/internal-auth" ||
     route.path === "/reset-password"
 );
+const isMarketingFullBleedRoute = computed(
+  () => route.path === "/" || route.path === "/landing-new"
+);
+const isDarkChromeRoute = computed(
+  () => route.path === "/" || route.path === "/landing-new" || route.path === "/pricing"
+);
 const showTopMenu = computed(
   () => route.name !== "public-home" && route.name !== "public-pricing"
 );
@@ -423,9 +437,26 @@ const appShellStyle = computed(() => ({
   "--top-banner-offset": topOffsetPx.value,
 }) as Record<string, string>);
 
+const updateBrowserChromeColor = () => {
+  const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+  if (!themeColorMeta) return;
+
+  let color = theme.value === "dark" ? "#0c1016" : "#f9f9f7";
+  if (isFullBleedRoute.value) {
+    color = theme.value === "dark" ? "#090c12" : "#e8eef3";
+  } else if (isDarkChromeRoute.value) {
+    color = "#090d14";
+  }
+
+  themeColorMeta.setAttribute("content", color);
+};
+
 watchEffect(() => {
   document.documentElement.classList.toggle("auth-route-active", isFullBleedRoute.value);
   document.body.classList.toggle("auth-route-active", isFullBleedRoute.value);
+  document.documentElement.classList.toggle("marketing-route-active", isDarkChromeRoute.value);
+  document.body.classList.toggle("marketing-route-active", isDarkChromeRoute.value);
+  updateBrowserChromeColor();
 });
 const topMenuStyle = computed(() => ({
   top: `calc(1rem + ${topOffsetPx.value})`,
@@ -458,6 +489,7 @@ const applyTheme = (next: "light" | "dark") => {
   theme.value = next;
   document.documentElement.setAttribute("data-theme", next);
   localStorage.setItem("itemtraxx-theme", next);
+  updateBrowserChromeColor();
 };
 
 const toggleTheme = () => {
@@ -804,12 +836,16 @@ const handlePageVisibilityChange = () => {
   if (document.visibilityState === "hidden") {
     stopStatusPolling();
     stopVersionPolling();
+    stopAdminSessionPolling();
     return;
   }
+  resetAdminIdleTimer();
+  startAdminSessionPolling();
   void refreshSystemStatus();
   startStatusPolling();
   void refreshVersionStatus();
   startVersionPolling();
+  refreshOfflineQueueCount();
 };
 
 const handleStorageChange = (event: StorageEvent) => {
@@ -846,7 +882,7 @@ onMounted(() => {
   refreshOfflineQueueCount();
   offlineQueueTimer = window.setInterval(() => {
     refreshOfflineQueueCount();
-  }, 3000);
+  }, 10000);
   window.addEventListener("resize", measureTopBanners);
   document.addEventListener("visibilitychange", handlePageVisibilityChange);
   resetAdminIdleTimer();

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -103,8 +103,11 @@ const unreadCount = computed(
     (maintenanceEnabled.value ? 1 : 0)
 );
 
-const loadNotifications = async () => {
-  isLoading.value = true;
+const loadNotifications = async (showLoading = true) => {
+  if (document.visibilityState === "hidden") return;
+  if (showLoading) {
+    isLoading.value = true;
+  }
   error.value = "";
   try {
     const payload = await fetchTenantNotifications();
@@ -126,8 +129,32 @@ const loadNotifications = async () => {
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Unable to load notifications.";
   } finally {
-    isLoading.value = false;
+    if (showLoading) {
+      isLoading.value = false;
+    }
   }
+};
+
+const startPolling = () => {
+  if (pollTimer) return;
+  pollTimer = window.setInterval(() => {
+    void loadNotifications(false);
+  }, 90_000);
+};
+
+const stopPolling = () => {
+  if (!pollTimer) return;
+  window.clearInterval(pollTimer);
+  pollTimer = null;
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === "hidden") {
+    stopPolling();
+    return;
+  }
+  void loadNotifications(false);
+  startPolling();
 };
 
 const toggleOpen = () => {
@@ -139,16 +166,13 @@ const toggleOpen = () => {
 
 onMounted(() => {
   void loadNotifications();
-  pollTimer = window.setInterval(() => {
-    void loadNotifications();
-  }, 60_000);
+  startPolling();
+  document.addEventListener("visibilitychange", handleVisibilityChange);
 });
 
 onUnmounted(() => {
-  if (pollTimer) {
-    window.clearInterval(pollTimer);
-    pollTimer = null;
-  }
+  stopPolling();
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
 });
 </script>
 

--- a/src/pages/LandingPageNew.vue
+++ b/src/pages/LandingPageNew.vue
@@ -28,14 +28,14 @@
     <main id="landing-new-main" class="shell landing-main">
       <section class="hero-grid reveal">
         <div class="hero-copy">
-          <p class="eyebrow">Closed beta now live | Individual plans coming soon</p>
+          <p class="eyebrow">Closed beta now live | Individual plans now available</p>
           <h1>ItemTraxx</h1>
           <p class="hero-body">
             Losing track of where stuff goes? ItemTraxx is the right service for you.
           </p>
           <p class="hero-support">
             Contact us to get early access and start mastering your inventory with ItemTraxx's
-            streamlined checkout, returns, and admin management.
+            streamlined checkout, returns, and admin management. Regular subscription terms apply.
           </p>
           <div class="hero-actions">
             <RouterLink class="cta-primary" to="/pricing" @click="trackCta('pricing', 'hero')">Pricing</RouterLink>
@@ -143,7 +143,7 @@
           <p class="eyebrow">Fit</p>
           <h3>Built for teams and organizations of any size.</h3>
           <p>
-            The product is flexible and scalable, making it a fit for schools, smaller teams, and
+            ItemTraxx is flexible and scalable, making it a fit for schools, smaller teams, and
             larger organizations that need cleaner inventory operations.
           </p>
         </article>
@@ -418,7 +418,7 @@ onBeforeUnmount(() => {
 .landing-new {
   position: relative;
   min-height: 100vh;
-  margin: -2.5rem -2rem -3rem;
+  margin: 0;
   padding: 1.35rem 0 4rem;
   overflow: hidden;
   color: #f5f7fb;
@@ -501,11 +501,12 @@ onBeforeUnmount(() => {
 
 .brand-mark {
   font-family: Helvetica, "Helvetica Neue", Arial, sans-serif;
-  font-size: 1.8rem;
+  font-size: 1.4rem;
   font-weight: 700;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.03em;
   color: #f6f7fb;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .landing-nav {
@@ -539,6 +540,7 @@ onBeforeUnmount(() => {
   gap: 0.55rem;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  white-space: nowrap;
 }
 
 .nav-cta,
@@ -932,21 +934,60 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 720px) {
-  .landing-new {
-    margin: -2.5rem -1rem -3rem;
-  }
-
   .shell {
     width: min(100%, calc(100% - 1.5rem));
   }
 
   .landing-header {
-    align-items: flex-start;
-    flex-direction: column;
+    align-items: center;
+    flex-direction: row;
+    gap: 0.7rem;
+    padding: 0.35rem 0 1.25rem;
   }
 
   .landing-nav {
-    width: 100%;
+    flex: 1;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding-left: 0.15rem;
+  }
+
+  .landing-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .brand-mark {
+    font-size: 1.15rem;
+    flex-shrink: 0;
+  }
+
+  .landing-nav a,
+  .status-pill,
+  .nav-cta {
+    font-size: 0.74rem;
+  }
+
+  .status-pill,
+  .nav-cta,
+  .cta-secondary,
+  .cta-primary {
+    min-height: 1.7rem;
+    padding: 0.26rem 0.58rem;
+    border-radius: 999px;
+  }
+
+  .status-pill {
+    gap: 0.38rem;
+    padding-inline: 0.52rem 0.62rem;
+  }
+
+  .status-dot {
+    width: 0.45rem;
+    height: 0.45rem;
   }
 
   .landing-footer {

--- a/src/pages/Pricing.vue
+++ b/src/pages/Pricing.vue
@@ -16,9 +16,11 @@
 
       <section class="pricing-hero">
         <p class="pricing-eyebrow">Pricing</p>
-        <h1>Simple annual pricing for teams of any size.</h1>
+        <h1>Simple pricing for teams of any size.</h1>
         <p class="pricing-lead">
-          Annual subscriptions by district size. All plans are subject to onboarding fees in year one.
+          Clear plan options for districts, organizations, and individual plans. Contact sales 
+          for custom quotes, multi-district pricing, or any questions about which plan is right
+            for you.
         </p>
         <div class="pricing-actions">
           <RouterLink class="pricing-contact-button" to="/contact-sales">
@@ -30,57 +32,170 @@
         </div>
       </section>
 
-      <section class="plan-grid" aria-label="Pricing plans">
-        <article class="plan-card">
-          <h2>ItemTraxx Core Plan</h2>
-          <p class="price">$1,250.00<span>/year</span></p>
-          <p class="price-note">Listed price excludes the 1st year onboarding fee.</p>
-          <ul>
-            <li>Up to 3 schools within the district</li>
-            <li>Unlimited staff accounts</li>
-            <li>Item tracking and status visibility</li>
-            <li>Checkout and return system</li>
-            <li>Standard support (72-hour response time)</li>
-          </ul>
-          <p class="onboarding">+1st Year Onboarding Fee: $750.00</p>
-        </article>
-
-        <article class="plan-card plan-highlight">
-          <h2>ItemTraxx Growth Plan</h2>
-          <p class="price">$3,500.00<span>/year</span></p>
-          <p class="price-note">Listed price excludes the 1st year onboarding fee.</p>
-          <ul>
-            <li>Up to 6 schools within the district</li>
-            <li>Unlimited staff accounts</li>
-            <li>Item tracking and status visibility</li>
-            <li>Checkout and return system</li>
-            <li>Standard support (72-hour response time)</li>
-          </ul>
-          <p class="onboarding">+1st Year Onboarding Fee: $1,250.00</p>
-        </article>
-
-        <article class="plan-card">
-          <h2>ItemTraxx Enterprise Plan</h2>
-          <p class="price">Contact for pricing</p>
-          <p class="starting">Starts at $4,500.00 (excluding 1st year fees)</p>
-          <ul>
-            <li>Base coverage for first 7 schools within the district</li>
-            <li>Unlimited staff accounts</li>
-            <li>Item tracking and status visibility</li>
-            <li>Checkout and return system</li>
-            <li>Priority support (24-hour response time)</li>
-          </ul>
-          <p class="onboarding">+1st Year Onboarding Fee: Contact for pricing (starts at $1,500.00)</p>
-          <p class="enterprise-note">
-            For full enterprise pricing (quote for more than 7 schools) and multi-district scope, use the contact sales button above.
+      <section class="pricing-section">
+        <div class="pricing-section-header">
+          <p class="pricing-section-eyebrow">District category</p>
+          <h2>District Pricing</h2>
+          <p>
+            Annual subscription pricing is based on the
+            number of schools in the district, with onboarding billed separately in year one (1) only.
           </p>
-        </article>
+        </div>
+
+        <section class="plan-grid" aria-label="District pricing plans">
+          <article class="plan-card">
+            <h3>ItemTraxx Core Plan</h3>
+            <p class="plan-meta">1-3 schools in district</p>
+            <p class="price">$1,250.00<span>/year</span></p>
+            <p class="price-note">Listed price excludes the 1st year onboarding fee.</p>
+            <ul>
+              <li>Up to 3 schools within the district</li>
+              <li>Unlimited staff accounts</li>
+              <li>Item tracking and status visibility</li>
+              <li>Checkout and return system</li>
+              <li>Standard support (72-hour response time)</li>
+            </ul>
+            <p class="onboarding">+1st Year Onboarding Fee: $750.00</p>
+          </article>
+
+          <article class="plan-card plan-highlight">
+            <h3>ItemTraxx Growth Plan</h3>
+            <p class="plan-meta">4-6 schools in district</p>
+            <p class="price">$3,500.00<span>/year</span></p>
+            <p class="price-note">Listed price excludes the 1st year onboarding fee.</p>
+            <ul>
+              <li>Up to 6 schools within the district</li>
+              <li>Unlimited staff accounts</li>
+              <li>Item tracking and status visibility</li>
+              <li>Checkout and return system</li>
+              <li>Standard support (72-hour response time)</li>
+            </ul>
+            <p class="onboarding">+1st Year Onboarding Fee: $1,250.00</p>
+          </article>
+
+          <article class="plan-card">
+            <h3>ItemTraxx Enterprise Plan</h3>
+            <p class="plan-meta">7+ schools in district</p>
+            <p class="price">Contact for pricing</p>
+            <p class="starting">Formula = $4,500 + (# of schools − 7) × $900 / year</p>
+            <ul>
+              <li>Base coverage for the first 7 schools within the district</li>
+              <li>Unlimited staff accounts</li>
+              <li>Item tracking and status visibility</li>
+              <li>Checkout and return system</li>
+              <li>Priority support (24-hour response time)</li>
+            </ul>
+            <p class="onboarding">
+              +1st Year Onboarding Fee: Contact for pricing ( Starts at $1,500.00)
+            </p>
+            <p class="enterprise-note">
+              For full enterprise pricing (quote for more than 7 schools) and multi-district scope,
+              use the contact sales button above.
+            </p>
+          </article>
+        </section>
       </section>
+
+      <section class="pricing-section">
+        <div class="pricing-section-header">
+          <p class="pricing-section-eyebrow">Organization category</p>
+          <h2>Organization Pricing</h2>
+          <p>
+            For non-school district teams, pricing is based on the number of locations or operating units.
+            Onboarding is billed seperatly in year one (1) only.
+          </p>
+        </div>
+
+        <section class="plan-grid" aria-label="Organization pricing plans">
+          <article class="plan-card">
+            <h3>Starter</h3>
+            <p class="plan-meta">1-3 locations or teams</p>
+            <p class="price">$1,250.00<span>/year</span></p>
+            <ul>
+              <li>Designed for smaller organizations and single-site operations</li>
+              <li>Checkout and return workflows for shared inventory</li>
+              <li>Staff access and core reporting</li>
+            </ul>
+            <p class="onboarding">Onboarding Fee: $500.00 / year</p>
+          </article>
+
+          <article class="plan-card plan-highlight">
+            <h3>Scale</h3>
+            <p class="plan-meta">4-7 locations or teams</p>
+            <p class="price">$3,500.00<span>/year</span></p>
+            <ul>
+              <li>Built for growing organizations with multiple operating units</li>
+              <li>District-style control across locations and teams</li>
+              <li>Expanded setup and support coverage</li>
+            </ul>
+            <p class="onboarding">Onboarding Fee: $1,000.00 / year</p>
+          </article>
+
+          <article class="plan-card">
+            <h3>Enterprise</h3>
+            <p class="plan-meta">7+ locations or teams</p>
+            <p class="price">Contact for pricing</p>
+            <p class="starting">Formula = $4,500 + (# of units − 7) × $900 / year</p>
+            <ul>
+              <li>For large multi-site organizations with custom rollout needs</li>
+              <li>Priority operational support and enterprise coordination</li>
+              <li>Units = max # of locations or teams</li>
+            </ul>
+            <p class="onboarding">
+              +1st Year Onboarding Fee: Contact for pricing (starts at $500.00)
+            </p>
+            <p class="enterprise-note">
+              For full enterprise pricing (quote for more than 7 locations or teams), use the
+              contact sales button above.
+            </p>
+          </article>
+        </section>
+      </section>
+
+      <section class="pricing-section">
+        <div class="pricing-section-header">
+          <p class="pricing-section-eyebrow">Individual category</p>
+          <h2>Individual Pricing</h2>
+          <p>
+            For single operators who need ItemTraxx without an organization or district structure.
+          </p>
+        </div>
+
+        <section class="plan-grid plan-grid-two" aria-label="Individual pricing plans">
+          <article class="plan-card">
+            <h3>Individual Yearly</h3>
+            <p class="plan-meta">Single-user plan</p>
+            <p class="price">$70.00<span>/year</span></p>
+            <ul>
+              <li>Single-user access on the main ItemTraxx app</li>
+              <li>Simple personal inventory tracking workflow</li>
+              <li>Invoice-based billing</li>
+            </ul>
+            <p class="onboarding">Onboarding not available</p>
+          </article>
+
+          <article class="plan-card">
+            <h3>Individual Monthly</h3>
+            <p class="plan-meta">Single-user plan</p>
+            <p class="price">$7.00<span>/month</span></p>
+            <ul>
+              <li>Month-to-month version of the individual plan</li>
+              <li>Single-user access on the main ItemTraxx app</li>
+              <li>Invoice-based billing</li>
+            </ul>
+            <p class="onboarding">Onboarding not available</p>
+          </article>
+        </section>
+      </section>
+
+      <div class="pricing-section-divider" aria-hidden="true">
+        <span></span>
+      </div>
 
       <section class="billing-card">
         <h2>Pricing FAQ</h2>
         <ul>
-          <li><strong>Are plans annual or monthly?</strong> All plans are annual subscriptions.</li>
+          <li><strong>Are plans annual or monthly?</strong> District and organization plans are annual. Individual plans are available annually or monthly.</li>
           <li><strong>When is onboarding charged?</strong> Onboarding is a one-time fee in year one only.</li>
           <li><strong>Can we move between plans?</strong> Yes. Upgrades are prorated; downgrades apply next billing cycle.</li>
           <li><strong>How do we request a formal quote?</strong> Use the Contact Sales button above and we will provide an official quote.</li>
@@ -91,20 +206,44 @@
         <h2>What Onboarding Includes</h2>
         <ul class="onboarding-includes-list">
           <li>
-            <strong>Core and Growth Plans:</strong>
+            <strong>District Core and Growth Plans:</strong>
             The onboarding fee is a one-time charge during year one and includes hassle-free
             addition of items and students (you provide inventory and existing records, and we
-            complete setup for you), a custom onboarding call (1-2 hours) covering product
+            complete setup for you), a custom onboarding call covering product
             features, account setup (logins), and live Q&A/help, plus a dedicated Slack support
-            channel during the first 3 months of use with a 24-hour response SLA.
+            channel during the first three (3) months of use with a 24-hour response SLA for the first
+            three (3) months of use, after that moves to 72-hour response SLA.
           </li>
           <li class="enterprise-onboarding-row">
-            <strong>Enterprise Plan:</strong>
+            <strong>District Enterprise Plan:</strong>
             The onboarding fee is a one-time charge during year one and includes hassle-free
             addition of items and students (you provide inventory and existing records, and we
-            complete setup for you), a custom onboarding call (1-2 hours) covering product
+            complete setup for you), a custom onboarding call covering product
             features, account setup (logins), and live Q&A/help, plus a dedicated Slack support
             channel with a 24-hour response SLA active throughout the full subscription term.
+          </li>
+          <li class="enterprise-onboarding-row">
+            <strong>Organization Starter and Scale Plans:</strong>
+            The onboarding fee is a one-time charge during year one and includes hassle-free
+            addition of items and members (you provide inventory and existing records, and we
+            complete setup for you), a custom onboarding call covering product
+            features, account setup (logins), and live Q&A/help, plus a dedicated Slack support
+            channel during the first three (3) months of use with a 24-hour response SLA for the first
+            three (3) months of use, after that moves to 72-hour response SLA.
+          </li>
+          <li class="enterprise-onboarding-row">
+            <strong>Organization Enterprise Plan:</strong>
+            The onboarding fee is a one-time charge during year one and includes hassle-free
+            addition of items and members (you provide inventory and existing records, and we
+            complete setup for you), a custom onboarding call covering product
+            features, account setup (logins), and live Q&A/help, plus a dedicated Slack support
+            channel with a 24-hour response SLA active throughout the full subscription term.
+          </li>
+          <li class="enterprise-onboarding-row">
+            <strong>Individual Plans:</strong>
+            Onboarding is not available for Individual Yearly or Individual Monthly plans. Individual
+            Yeary and Individual Monthly plans have regular access to our support team via email with a 
+            72-hour response SLA.
           </li>
         </ul>
       </section>
@@ -112,9 +251,9 @@
       <section class="billing-card">
         <h2>Billing Terms</h2>
         <ul>
-          <li>All plans are billed annually.</li>
+          <li>District and organization plans are billed annually. Individual plans are available annually or monthly.</li>
           <li>Applicable taxes and government fees are not included in listed pricing.</li>
-          <li>Onboarding fee applies only to year one (1) of subscription and is required.</li>
+          <li>Onboarding fee applies only to year one (1) of District and Organization subscription plans and is required.</li>
           <li>Renewal terms and final scope are confirmed in the signed agreement.</li>
           <li>
             Full subscription policies:
@@ -325,6 +464,38 @@ import { RouterLink } from "vue-router";
     0 16px 32px rgba(25, 194, 168, 0.14);
 }
 
+.pricing-section {
+  margin-top: 1.75rem;
+}
+
+.pricing-section-header {
+  max-width: 52rem;
+  margin-bottom: 1rem;
+}
+
+.pricing-section-eyebrow {
+  margin: 0 0 0.45rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(214, 237, 233, 0.68);
+}
+
+.pricing-section-header h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.8vw, 2.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  color: #f7fbff;
+}
+
+.pricing-section-header p {
+  margin: 0.8rem 0 0;
+  line-height: 1.7;
+  color: rgba(222, 229, 238, 0.74);
+}
+
 .plan-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -346,6 +517,21 @@ import { RouterLink } from "vue-router";
   margin: 0;
   font-size: 1.2rem;
   color: #f5f7fb;
+}
+
+.plan-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #f5f7fb;
+}
+
+.plan-meta {
+  margin: 0.4rem 0 0;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(137, 239, 225, 0.78);
 }
 
 .price {
@@ -424,6 +610,27 @@ import { RouterLink } from "vue-router";
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
 }
 
+.pricing-section-divider {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+}
+
+.pricing-section-divider span {
+  width: min(220px, 32vw);
+  height: 1px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(25, 194, 168, 0) 0%,
+    rgba(25, 194, 168, 0.55) 20%,
+    rgba(68, 111, 207, 0.62) 50%,
+    rgba(25, 194, 168, 0.55) 80%,
+    rgba(25, 194, 168, 0) 100%
+  );
+  box-shadow: 0 0 28px rgba(25, 194, 168, 0.12);
+}
+
 .billing-card h2 {
   margin-top: 0;
   color: #f5f7fb;
@@ -470,6 +677,16 @@ import { RouterLink } from "vue-router";
   }
 
   .plan-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.plan-grid-two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 980px) {
+  .plan-grid-two {
     grid-template-columns: 1fr;
   }
 }

--- a/src/pages/PublicHome.vue
+++ b/src/pages/PublicHome.vue
@@ -350,7 +350,20 @@ const scheduleIdle = (callback: () => void, timeout = 1200) => {
 
 let cancelIdlePrefetch: (() => void) | null = null;
 
+const shouldPrefetchPrimaryRoutes = () => {
+  const connection = (navigator as Navigator & {
+    connection?: { saveData?: boolean; effectiveType?: string };
+  }).connection;
+  if (connection?.saveData) {
+    return false;
+  }
+  return connection?.effectiveType !== "slow-2g" && connection?.effectiveType !== "2g";
+};
+
 const prefetchPrimaryRoutes = () => {
+  if (!shouldPrefetchPrimaryRoutes() || document.visibilityState === "hidden") {
+    return;
+  }
   void import("./Login.vue");
   void import("./tenant/Checkout.vue");
   void import("./tenant/admin/AdminLogin.vue");

--- a/src/pages/internal/InternalOps.vue
+++ b/src/pages/internal/InternalOps.vue
@@ -332,6 +332,13 @@ const viewFlags = ref<ViewFlags>({ ...DEFAULT_VIEW_FLAGS });
 let pollTimer: number | null = null;
 let toastTimer: number | null = null;
 
+const stopPolling = () => {
+  if (pollTimer !== null) {
+    window.clearInterval(pollTimer);
+    pollTimer = null;
+  }
+};
+
 const showToast = (title: string, message: string) => {
   toastTitle.value = title;
   toastMessage.value = message;
@@ -556,10 +563,22 @@ const saveCurrentPreset = () => {
 };
 
 const startPolling = () => {
-  if (pollTimer !== null) window.clearInterval(pollTimer);
+  if (document.visibilityState === "hidden") return;
+  stopPolling();
   pollTimer = window.setInterval(() => {
-    void loadSnapshot();
-  }, 15000);
+    if (document.visibilityState === "visible") {
+      void loadSnapshot();
+    }
+  }, 15_000);
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === "hidden") {
+    stopPolling();
+    return;
+  }
+  void loadSnapshot();
+  startPolling();
 };
 
 onMounted(async () => {
@@ -567,10 +586,12 @@ onMounted(async () => {
   applyPreset("default");
   await loadSnapshot();
   startPolling();
+  document.addEventListener("visibilitychange", handleVisibilityChange);
 });
 
 onUnmounted(() => {
-  if (pollTimer !== null) window.clearInterval(pollTimer);
+  stopPolling();
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
   if (toastTimer !== null) window.clearTimeout(toastTimer);
 });
 </script>

--- a/src/pages/super/Tenants.vue
+++ b/src/pages/super/Tenants.vue
@@ -34,62 +34,22 @@
         <h3>District linked</h3>
         <p class="stat-value">{{ districtLinkedTenantCount }}</p>
       </div>
+      <div class="stat-card">
+        <h3>Individual</h3>
+        <p class="stat-value">{{ individualTenantCount }}</p>
+      </div>
     </div>
 
     <div class="section-grid">
       <div class="card section-card">
         <div class="section-heading">
-          <h2>Create Tenant</h2>
-          <p class="muted">Provision tenant access and attach it to an active district.</p>
-        </div>
-      <form class="form" @submit.prevent="handleCreate">
-        <label>
-          Name
-          <input v-model="createName" type="text" placeholder="Tenant name" />
-        </label>
-        <label>
-          Access Code
-          <input v-model="createAccessCode" type="text" placeholder="Access code" />
-        </label>
-        <label>
-          Tenant Admin Email
-          <input v-model="createAuthEmail" type="email" placeholder="admin@tenant.com" />
-        </label>
-        <label>
-          Tenant Admin Password
-          <input
-            v-model="createPassword"
-            type="password"
-            placeholder="Minimum 8 characters"
-            autocomplete="off"
-          />
-        </label>
-        <label>
-          Status
-          <select v-model="createStatusLabel">
-            <option value="active">active</option>
-            <option value="disabled">disabled</option>
-          </select>
-        </label>
-        <label>
-          District
-          <select v-model="createDistrictId">
-            <option value="">No district</option>
-            <option v-for="district in activeDistricts" :key="district.id" :value="district.id">
-              {{ district.name }} ({{ district.slug }})
-            </option>
-          </select>
-        </label>
-        <div class="form-actions">
-          <button type="submit" class="button-primary" :disabled="isSaving">Create Tenant</button>
-        </div>
-      </form>
-      </div>
-
-      <div class="card section-card">
-        <div class="section-heading">
-          <h2>Tenant List</h2>
-          <p class="muted">Search, filter, edit, and change tenant status from one table.</p>
+          <div>
+            <h2>Tenant List</h2>
+            <p class="muted">Search, filter, edit, and change tenant status from one table.</p>
+          </div>
+          <button type="button" class="button-primary" @click="createModalVisible = true">
+            Create New Tenant
+          </button>
         </div>
         <div class="filter-toolbar">
           <div class="input-row">
@@ -109,41 +69,117 @@
 
         <p v-if="isLoading" class="muted">Loading tenants...</p>
         <p v-else-if="error" class="error">{{ error }}</p>
-        <table v-else class="table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>District</th>
-              <th>Access Code</th>
-              <th>Status</th>
-              <th>Primary Admin</th>
-              <th>Created</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="tenant in tenants" :key="tenant.id">
-              <td>{{ tenant.name }}</td>
-              <td>{{ tenant.district_slug || tenant.district_name || "-" }}</td>
-              <td>{{ tenant.access_code }}</td>
-              <td>{{ toTenantStatusLabel(tenant.status) }}</td>
-              <td>{{ tenant.primary_admin_email || "-" }}</td>
-              <td>{{ formatDate(tenant.created_at) }}</td>
-              <td class="actions-cell">
-                <button type="button" @click="openEditModal(tenant)">Edit</button>
-                <button type="button" :disabled="isSaving" @click="openStatusModal(tenant)">
-                  {{
-                    tenant.status === "active"
-                      ? "Disable"
-                      : tenant.status === "suspended"
-                        ? "Reactivate"
-                        : "Restore"
-                  }}
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <div v-else class="table-wrap tenant-table-wrap">
+          <table class="table tenant-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Plan</th>
+                <th>District</th>
+                <th>Access Code</th>
+                <th>Status</th>
+                <th>Primary Admin</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="tenant in tenants" :key="tenant.id">
+                <td>{{ tenant.name }}</td>
+                <td>{{ formatAccountCategory(tenant.account_category) }}</td>
+                <td>{{ formatPlanCode(tenant.plan_code) }}</td>
+                <td>{{ tenant.district_slug || tenant.district_name || "-" }}</td>
+                <td>{{ tenant.access_code }}</td>
+                <td>{{ toTenantStatusLabel(tenant.status) }}</td>
+                <td>{{ tenant.primary_admin_email || "-" }}</td>
+                <td>{{ formatDate(tenant.created_at) }}</td>
+                <td class="actions-cell">
+                  <button type="button" @click="openEditModal(tenant)">Edit</button>
+                  <button type="button" :disabled="isSaving" @click="openStatusModal(tenant)">
+                    {{
+                      tenant.status === "active"
+                        ? "Disable"
+                        : tenant.status === "suspended"
+                          ? "Reactivate"
+                          : "Restore"
+                    }}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="createModalVisible" class="modal-backdrop" @click.self="closeCreateModal">
+      <div class="modal">
+        <h2>Create Tenant</h2>
+        <p class="muted modal-copy">Provision tenant access and attach it to an active district.</p>
+        <form class="form" @submit.prevent="handleCreate">
+          <label>
+            Name
+            <input v-model="createName" type="text" placeholder="Tenant name" />
+          </label>
+          <label>
+            Access Code
+            <input v-model="createAccessCode" type="text" placeholder="Access code" />
+          </label>
+          <label>
+            Tenant Admin Email
+            <input v-model="createAuthEmail" type="email" placeholder="admin@tenant.com" />
+          </label>
+          <label>
+            Tenant Admin Password
+            <input
+              v-model="createPassword"
+              type="password"
+              placeholder="Minimum 8 characters"
+              autocomplete="off"
+            />
+          </label>
+          <label>
+            Account Type
+            <select v-model="createAccountCategory">
+              <option value="organization">Organization</option>
+              <option value="district">District</option>
+              <option value="individual">Individual</option>
+            </select>
+          </label>
+          <label>
+            Plan
+            <select v-model="createPlanCode">
+              <option
+                v-for="option in createPlanOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label>
+            Status
+            <select v-model="createStatusLabel">
+              <option value="active">active</option>
+              <option value="disabled">disabled</option>
+            </select>
+          </label>
+          <label v-if="createAccountCategory !== 'individual'">
+            District
+            <select v-model="createDistrictId">
+              <option value="">No district</option>
+              <option v-for="district in activeDistricts" :key="district.id" :value="district.id">
+                {{ district.name }} ({{ district.slug }})
+              </option>
+            </select>
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="button-primary" :disabled="isSaving">Create Tenant</button>
+            <button type="button" @click="closeCreateModal">Cancel</button>
+          </div>
+        </form>
       </div>
     </div>
 
@@ -160,6 +196,26 @@
             <input v-model="editAccessCode" type="text" placeholder="Access code" />
           </label>
           <label>
+            Account Type
+            <select v-model="editAccountCategory">
+              <option value="organization">Organization</option>
+              <option value="district">District</option>
+              <option value="individual">Individual</option>
+            </select>
+          </label>
+          <label>
+            Plan
+            <select v-model="editPlanCode">
+              <option
+                v-for="option in editPlanOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label v-if="editAccountCategory !== 'individual'">
             District
             <select v-model="editDistrictId">
               <option value="">No district</option>
@@ -221,7 +277,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 import StepUpModal from "../../components/StepUpModal.vue";
 import { setTenantPolicy } from "../../services/superOpsService";
@@ -249,15 +305,32 @@ const createName = ref("");
 const createAccessCode = ref("");
 const createAuthEmail = ref("");
 const createPassword = ref("");
+const createAccountCategory = ref<"organization" | "district" | "individual">("organization");
+const createPlanCode = ref<
+  "core" | "growth" | "starter" | "scale" | "enterprise" | "individual_yearly" | "individual_monthly"
+>("starter");
 const createStatusLabel = ref<"active" | "disabled">("active");
 const createDistrictId = ref("");
+const createModalVisible = ref(false);
 const editTenantId = ref<string | null>(null);
 const editModalVisible = ref(false);
 const editName = ref("");
 const editAccessCode = ref("");
+const editAccountCategory = ref<"organization" | "district" | "individual">("organization");
+const editPlanCode = ref<
+  "core" | "growth" | "starter" | "scale" | "enterprise" | "individual_yearly" | "individual_monthly"
+>("starter");
 const editDistrictId = ref("");
 const editCheckoutDueHours = ref(72);
 const editFeatureFlags = ref({
+  enable_notifications: true,
+  enable_bulk_item_import: true,
+  enable_bulk_student_tools: true,
+  enable_status_tracking: true,
+  enable_barcode_generator: true,
+});
+const initialEditCheckoutDueHours = ref(72);
+const initialEditFeatureFlags = ref({
   enable_notifications: true,
   enable_bulk_item_import: true,
   enable_bulk_student_tools: true,
@@ -283,6 +356,53 @@ const disabledTenantCount = computed(() =>
 const districtLinkedTenantCount = computed(() =>
   tenants.value.filter((tenant) => !!tenant.district_id).length
 );
+const individualTenantCount = computed(
+  () => tenants.value.filter((tenant) => tenant.account_category === "individual").length
+);
+
+const planOptionsByCategory = {
+  district: [
+    { value: "core", label: "Core" },
+    { value: "growth", label: "Growth" },
+    { value: "enterprise", label: "Enterprise" },
+  ],
+  organization: [
+    { value: "starter", label: "Starter" },
+    { value: "scale", label: "Scale" },
+    { value: "enterprise", label: "Enterprise" },
+  ],
+  individual: [
+    { value: "individual_yearly", label: "Individual Yearly" },
+    { value: "individual_monthly", label: "Individual Monthly" },
+  ],
+} as const;
+
+const createPlanOptions = computed(() => planOptionsByCategory[createAccountCategory.value]);
+const editPlanOptions = computed(() => planOptionsByCategory[editAccountCategory.value]);
+
+const formatAccountCategory = (value: SuperTenant["account_category"]) =>
+  value === "individual" ? "Individual" : value === "district" ? "District" : "Organization";
+
+const formatPlanCode = (value: SuperTenant["plan_code"]) => {
+  switch (value) {
+    case "core":
+      return "Core";
+    case "growth":
+      return "Growth";
+    case "starter":
+      return "Starter";
+    case "scale":
+      return "Scale";
+    case "enterprise":
+      return "Enterprise";
+    case "individual_yearly":
+      return "Individual Yearly";
+    case "individual_monthly":
+      return "Individual Monthly";
+    default:
+      return "-";
+  }
+};
 
 const showToast = (title: string, message: string) => {
   toastTitle.value = title;
@@ -353,16 +473,23 @@ const handleCreate = async () => {
       auth_email: createAuthEmail.value.trim().toLowerCase(),
       password: createPassword.value,
       status: fromTenantStatusLabel(createStatusLabel.value),
-      district_name: selectedDistrict?.name || undefined,
-      district_slug: selectedDistrict?.slug || undefined,
+      account_category: createAccountCategory.value,
+      plan_code: createPlanCode.value,
+      district_name:
+        createAccountCategory.value !== "individual" ? selectedDistrict?.name || undefined : undefined,
+      district_slug:
+        createAccountCategory.value !== "individual" ? selectedDistrict?.slug || undefined : undefined,
     });
     tenants.value = [created, ...tenants.value];
     createName.value = "";
     createAccessCode.value = "";
     createAuthEmail.value = "";
     createPassword.value = "";
+    createAccountCategory.value = "organization";
+    createPlanCode.value = "starter";
     createStatusLabel.value = "active";
     createDistrictId.value = "";
+    createModalVisible.value = false;
     showToast("Tenant created", "Tenant and tenant admin login were created successfully.");
   } catch (err) {
     showToast("Create failed", err instanceof Error ? err.message : "Unable to create tenant.");
@@ -371,10 +498,35 @@ const handleCreate = async () => {
   }
 };
 
+const closeCreateModal = () => {
+  createModalVisible.value = false;
+  createName.value = "";
+  createAccessCode.value = "";
+  createAuthEmail.value = "";
+  createPassword.value = "";
+  createAccountCategory.value = "organization";
+  createPlanCode.value = "starter";
+  createStatusLabel.value = "active";
+  createDistrictId.value = "";
+};
+
 const openEditModal = (tenant: SuperTenant) => {
   editTenantId.value = tenant.id;
   editName.value = tenant.name;
   editAccessCode.value = tenant.access_code;
+  editAccountCategory.value =
+    tenant.account_category === "individual"
+      ? "individual"
+      : tenant.account_category === "district"
+        ? "district"
+        : "organization";
+  editPlanCode.value =
+    tenant.plan_code ??
+    (tenant.account_category === "individual"
+      ? "individual_yearly"
+      : tenant.account_category === "district"
+        ? "core"
+        : "starter");
   editDistrictId.value = tenant.district_id ?? "";
   editCheckoutDueHours.value =
     typeof tenant.checkout_due_hours === "number"
@@ -387,6 +539,8 @@ const openEditModal = (tenant: SuperTenant) => {
     enable_status_tracking: tenant.feature_flags?.enable_status_tracking !== false,
     enable_barcode_generator: tenant.feature_flags?.enable_barcode_generator !== false,
   };
+  initialEditCheckoutDueHours.value = editCheckoutDueHours.value;
+  initialEditFeatureFlags.value = { ...editFeatureFlags.value };
   editModalVisible.value = true;
 };
 
@@ -395,8 +549,18 @@ const closeEditModal = () => {
   editTenantId.value = null;
   editName.value = "";
   editAccessCode.value = "";
+  editAccountCategory.value = "organization";
+  editPlanCode.value = "starter";
   editDistrictId.value = "";
   editCheckoutDueHours.value = 72;
+  initialEditCheckoutDueHours.value = 72;
+  initialEditFeatureFlags.value = {
+    enable_notifications: true,
+    enable_bulk_item_import: true,
+    enable_bulk_student_tools: true,
+    enable_status_tracking: true,
+    enable_barcode_generator: true,
+  };
 };
 
 const saveEdit = async () => {
@@ -423,17 +587,26 @@ const saveEdit = async () => {
       id: editTenantId.value,
       name: editName.value.trim(),
       access_code: editAccessCode.value.trim(),
-      district_name: selectedDistrict?.name || undefined,
-      district_slug: selectedDistrict?.slug || undefined,
+      account_category: editAccountCategory.value,
+      plan_code: editPlanCode.value,
+      district_name:
+        editAccountCategory.value !== "individual" ? selectedDistrict?.name || undefined : undefined,
+      district_slug:
+        editAccountCategory.value !== "individual" ? selectedDistrict?.slug || undefined : undefined,
     });
     tenants.value = tenants.value.map((tenant) =>
       tenant.id === updated.id ? updated : tenant
     );
-    await setTenantPolicy({
-      tenant_id: editTenantId.value,
-      checkout_due_hours: Math.round(editCheckoutDueHours.value),
-      feature_flags: editFeatureFlags.value,
-    });
+    const policyChanged =
+      Math.round(editCheckoutDueHours.value) !== initialEditCheckoutDueHours.value ||
+      JSON.stringify(editFeatureFlags.value) !== JSON.stringify(initialEditFeatureFlags.value);
+    if (policyChanged) {
+      await setTenantPolicy({
+        tenant_id: editTenantId.value,
+        checkout_due_hours: Math.round(editCheckoutDueHours.value),
+        feature_flags: editFeatureFlags.value,
+      });
+    }
     await loadTenants();
     closeEditModal();
     showToast("Tenant updated", "Tenant details were updated.");
@@ -515,9 +688,29 @@ onMounted(() => {
   void loadTenants();
   void loadDistrictOptions();
 });
+
+watch(createAccountCategory, (value) => {
+  createPlanCode.value =
+    value === "individual" ? "individual_yearly" : value === "district" ? "core" : "starter";
+  if (value === "individual") {
+    createDistrictId.value = "";
+  }
+});
+
+watch(editAccountCategory, (value) => {
+  editPlanCode.value =
+    value === "individual" ? "individual_yearly" : value === "district" ? "core" : "starter";
+  if (value === "individual") {
+    editDistrictId.value = "";
+  }
+});
 </script>
 
 <style scoped>
+.page {
+  max-width: 1360px;
+}
+
 .super-page-header {
   display: flex;
   justify-content: space-between;
@@ -536,7 +729,7 @@ onMounted(() => {
 
 .section-grid {
   display: grid;
-  grid-template-columns: minmax(300px, 340px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 1rem;
   align-items: start;
 }
@@ -566,6 +759,45 @@ onMounted(() => {
   min-width: 180px;
 }
 
+.modal-copy {
+  margin: -0.4rem 0 0.25rem;
+}
+
+.tenant-table-wrap {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.25rem;
+}
+
+.tenant-table {
+  min-width: 0;
+  margin-top: 0;
+}
+
+.tenant-table td,
+.tenant-table th {
+  vertical-align: top;
+}
+
+.tenant-table td:nth-child(1),
+.tenant-table td:nth-child(4),
+.tenant-table td:nth-child(7) {
+  min-width: 8.5rem;
+  word-break: break-word;
+}
+
+.tenant-table td:nth-child(5),
+.tenant-table th:nth-child(5) {
+  white-space: nowrap;
+}
+
+.tenant-table td:nth-child(8),
+.tenant-table th:nth-child(8) {
+  white-space: nowrap;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -590,6 +822,7 @@ onMounted(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  white-space: nowrap;
 }
 
 @media (max-width: 900px) {
@@ -599,10 +832,6 @@ onMounted(() => {
 
   .super-page-links {
     justify-content: flex-start;
-  }
-
-  .section-grid {
-    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/src/pages/tenant/admin/AdminHome.vue
+++ b/src/pages/tenant/admin/AdminHome.vue
@@ -9,10 +9,20 @@
           </div>
           <div class="muted">Signed in as {{ adminEmail }}</div>
         </div>
-        <h1>Admin Panel</h1>
+      <h1>Admin Panel</h1>
         <p class="admin-hero-copy">
           Manage inventory, students, returns, reporting, and tenant controls from one workspace.
         </p>
+        <div class="admin-summary-grid">
+          <div class="admin-summary-card">
+            <strong>{{ accountCategoryLabel }}</strong>
+            <span>Account category</span>
+          </div>
+          <div class="admin-summary-card">
+            <strong>{{ planLabel }}</strong>
+            <span>Plan</span>
+          </div>
+        </div>
       </div>
 
     <div class="admin-grid">
@@ -61,7 +71,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive } from "vue";
+import { computed, onMounted, reactive, ref } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 import {
   clearAdminVerification,
@@ -80,8 +90,48 @@ const featureFlags = reactive({
   enable_status_tracking: true,
   enable_barcode_generator: true,
 });
+const accountCategory = ref<"organization" | "district" | "individual" | null>(null);
+const planCode = ref<
+  | "core"
+  | "growth"
+  | "starter"
+  | "scale"
+  | "enterprise"
+  | "individual_yearly"
+  | "individual_monthly"
+  | null
+>(null);
 
 const router = useRouter();
+const accountCategoryLabel = computed(() =>
+  accountCategory.value === "individual"
+    ? "Individual"
+    : accountCategory.value === "district"
+      ? "District"
+    : accountCategory.value === "organization"
+      ? "Organization"
+      : "Unavailable"
+);
+const planLabel = computed(() => {
+  switch (planCode.value) {
+    case "core":
+      return "Core";
+    case "growth":
+      return "Growth";
+    case "starter":
+      return "Starter";
+    case "scale":
+      return "Scale";
+    case "enterprise":
+      return "Enterprise";
+    case "individual_yearly":
+      return "Individual Yearly";
+    case "individual_monthly":
+      return "Individual Monthly";
+    default:
+      return "Unavailable";
+  }
+});
 
 const returnToCheckout = async () => {
   clearAdminVerification();
@@ -92,6 +142,15 @@ onMounted(async () => {
   try {
     const settings = await fetchTenantSettings();
     Object.assign(featureFlags, settings.feature_flags);
+    accountCategory.value =
+      settings.account_category === "individual"
+        ? "individual"
+        : settings.account_category === "district"
+          ? "district"
+        : settings.account_category === "organization"
+          ? "organization"
+          : null;
+    planCode.value = settings.plan_code ?? null;
   } catch {
     // Keep defaults if tenant settings cannot be loaded.
   }

--- a/src/pages/tenant/admin/AdminLogin.vue
+++ b/src/pages/tenant/admin/AdminLogin.vue
@@ -147,12 +147,14 @@ const handleAdminLogin = async () => {
           email.value.trim(),
           password.value
         );
-        const targetPath =
-          handoff.role === "district_admin" ? "/district" : "/tenant/admin";
-        window.location.assign(
-          buildDistrictAppHandoffUrl(handoff.districtSlug, targetPath, handoff.code)
-        );
-        return;
+        if (!handoff.rootOnly && handoff.code && handoff.districtSlug) {
+          const targetPath =
+            handoff.role === "district_admin" ? "/district" : "/tenant/admin";
+          window.location.assign(
+            buildDistrictAppHandoffUrl(handoff.districtSlug, targetPath, handoff.code)
+          );
+          return;
+        }
       } catch (handoffError) {
         const handoffMessage =
           handoffError instanceof Error ? handoffError.message : "";

--- a/src/pages/tenant/admin/Settings.vue
+++ b/src/pages/tenant/admin/Settings.vue
@@ -12,10 +12,46 @@
           <span>Due window (hours)</span>
         </div>
         <div class="admin-summary-card">
+          <strong>{{ accountCategoryLabel }}</strong>
+          <span>Account category</span>
+        </div>
+        <div class="admin-summary-card">
+          <strong>{{ planLabel }}</strong>
+          <span>Plan</span>
+        </div>
+        <div class="admin-summary-card">
           <strong>{{ sessions.length }}</strong>
           <span>Active devices</span>
         </div>
       </div>
+    </div>
+
+    <div class="card admin-section-card">
+      <div class="admin-section-header">
+        <div>
+          <h2>Account Overview</h2>
+          <p class="admin-section-copy">Review how this workspace is classified for billing and support.</p>
+        </div>
+      </div>
+      <div class="admin-summary-grid">
+        <div class="admin-summary-card">
+          <strong>{{ accountCategoryLabel }}</strong>
+          <span>Workspace type</span>
+        </div>
+        <div class="admin-summary-card">
+          <strong>{{ planLabel }}</strong>
+          <span>Assigned plan</span>
+        </div>
+      </div>
+      <p class="muted">
+        {{
+          accountCategory === "individual"
+            ? "This account uses the root ItemTraxx workspace and is not attached to a district subdomain."
+            : accountCategory === "organization"
+              ? "Organization and district-linked accounts inherit their routing and billing context from tenant configuration."
+              : "Account plan metadata has not been configured for this tenant yet."
+        }}
+      </p>
     </div>
 
     <div class="card admin-section-card">
@@ -129,6 +165,17 @@ const isSaving = ref(false);
 const error = ref("");
 const success = ref("");
 const checkoutDueHours = ref(72);
+const accountCategory = ref<"organization" | "district" | "individual" | null>(null);
+const planCode = ref<
+  | "core"
+  | "growth"
+  | "starter"
+  | "scale"
+  | "enterprise"
+  | "individual_yearly"
+  | "individual_monthly"
+  | null
+>(null);
 const sessions = ref<TenantSessionItem[]>([]);
 const selectedSessionId = ref("");
 const isSessionSaving = ref(false);
@@ -153,7 +200,47 @@ const showToast = (title: string, message: string) => {
 
 const applySettings = (settings: TenantSettingsPayload) => {
   checkoutDueHours.value = settings.checkout_due_hours;
+  accountCategory.value =
+    settings.account_category === "individual"
+      ? "individual"
+      : settings.account_category === "district"
+        ? "district"
+      : settings.account_category === "organization"
+        ? "organization"
+        : null;
+  planCode.value = settings.plan_code ?? null;
 };
+
+const accountCategoryLabel = computed(() =>
+  accountCategory.value === "individual"
+    ? "Individual"
+    : accountCategory.value === "district"
+      ? "District"
+    : accountCategory.value === "organization"
+      ? "Organization"
+      : "Unavailable"
+);
+
+const planLabel = computed(() => {
+  switch (planCode.value) {
+    case "core":
+      return "Core";
+    case "growth":
+      return "Growth";
+    case "starter":
+      return "Starter";
+    case "scale":
+      return "Scale";
+    case "enterprise":
+      return "Enterprise";
+    case "individual_yearly":
+      return "Individual Yearly";
+    case "individual_monthly":
+      return "Individual Monthly";
+    default:
+      return "Unavailable";
+  }
+});
 
 const removableSessions = computed(() =>
   sessions.value.filter((session) => !session.is_current)

--- a/src/services/adminOpsService.ts
+++ b/src/services/adminOpsService.ts
@@ -42,6 +42,16 @@ export type TenantNotificationPayload = {
 
 export type TenantSettingsPayload = {
   checkout_due_hours: number;
+  account_category: "organization" | "district" | "individual" | null;
+  plan_code:
+    | "core"
+    | "growth"
+    | "starter"
+    | "scale"
+    | "enterprise"
+    | "individual_yearly"
+    | "individual_monthly"
+    | null;
   feature_flags: TenantFeatureFlags;
 };
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -557,7 +557,12 @@ export const createDistrictAdminSessionHandoff = async (
   password: string
 ) => {
   const result = await invokeEdgeFunction<
-    { code?: string; district_slug?: string; role?: "tenant_admin" | "district_admin" },
+    {
+      code?: string | null;
+      district_slug?: string | null;
+      role?: "tenant_admin" | "district_admin";
+      root_only?: boolean;
+    },
     { action: "create_admin"; email: string; password: string }
   >(getDistrictHandoffFunctionName(), {
     method: "POST",
@@ -567,6 +572,15 @@ export const createDistrictAdminSessionHandoff = async (
       password,
     },
   });
+
+  if (result.ok && result.data?.root_only) {
+    return {
+      code: null,
+      districtSlug: null,
+      role: result.data.role ?? "tenant_admin",
+      rootOnly: true,
+    };
+  }
 
   if (!result.ok || !result.data?.code || !result.data?.district_slug || !result.data?.role) {
     if (!result.ok && result.error === "Tenant disabled") {
@@ -588,6 +602,7 @@ export const createDistrictAdminSessionHandoff = async (
     code: result.data.code,
     districtSlug: result.data.district_slug,
     role: result.data.role,
+    rootOnly: false,
   };
 };
 

--- a/src/services/superTenantService.ts
+++ b/src/services/superTenantService.ts
@@ -14,6 +14,16 @@ export type SuperTenant = {
   primary_admin_profile_id?: string | null;
   primary_admin_email?: string | null;
   checkout_due_hours?: number;
+  account_category?: "organization" | "district" | "individual";
+  plan_code?:
+    | "core"
+    | "growth"
+    | "starter"
+    | "scale"
+    | "enterprise"
+    | "individual_yearly"
+    | "individual_monthly"
+    | null;
   feature_flags?: {
     enable_notifications?: boolean;
     enable_bulk_item_import?: boolean;
@@ -104,6 +114,47 @@ type SuperTenantRequest = {
 
 const getAccessToken = getFreshAccessToken;
 
+const OPTION_CACHE_TTL_MS = 30_000;
+const optionCache = new Map<string, { expiresAt: number; value: unknown }>();
+const optionInflight = new Map<string, Promise<unknown>>();
+
+const withCachedOptions = async <TData>(key: string, loader: () => Promise<TData>) => {
+  const cached = optionCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value as TData;
+  }
+
+  const pending = optionInflight.get(key);
+  if (pending) {
+    return pending as Promise<TData>;
+  }
+
+  const next = loader()
+    .then((value) => {
+      optionCache.set(key, { expiresAt: Date.now() + OPTION_CACHE_TTL_MS, value });
+      return value;
+    })
+    .finally(() => {
+      optionInflight.delete(key);
+    });
+
+  optionInflight.set(key, next as Promise<unknown>);
+  return next;
+};
+
+const invalidateOptionCaches = (...prefixes: string[]) => {
+  for (const key of Array.from(optionCache.keys())) {
+    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+      optionCache.delete(key);
+    }
+  }
+  for (const key of Array.from(optionInflight.keys())) {
+    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+      optionInflight.delete(key);
+    }
+  }
+};
+
 const callSuperTenant = async <TData>(payload: SuperTenantRequest) => {
   const accessToken = await getAccessToken();
   const result = await invokeEdgeFunction<EdgeEnvelope<TData>, SuperTenantRequest>(
@@ -128,11 +179,21 @@ export const toTenantStatusLabel = (status: SuperTenant["status"]) =>
 export const fromTenantStatusLabel = (label: "active" | "disabled" | "archived") =>
   label === "disabled" ? "suspended" : label;
 
-export const listTenants = async (search = "", status = "all") =>
-  callSuperTenant<SuperTenant[]>({
-    action: "list_tenants",
-    payload: { search, status },
-  });
+export const listTenants = async (search = "", status = "all") => {
+  const normalizedSearch = search.trim();
+  const cacheKey = `tenants:${status}:${normalizedSearch.toLowerCase()}`;
+  const loader = () =>
+    callSuperTenant<SuperTenant[]>({
+      action: "list_tenants",
+      payload: { search: normalizedSearch, status },
+    });
+
+  if (!normalizedSearch && status === "all") {
+    return withCachedOptions(cacheKey, loader);
+  }
+
+  return loader();
+};
 
 export const createTenant = async (payload: {
   name: string;
@@ -140,24 +201,48 @@ export const createTenant = async (payload: {
   auth_email: string;
   password: string;
   status: "active" | "suspended" | "archived";
+  account_category?: "organization" | "district" | "individual";
+  plan_code?:
+    | "core"
+    | "growth"
+    | "starter"
+    | "scale"
+    | "enterprise"
+    | "individual_yearly"
+    | "individual_monthly";
   district_name?: string;
   district_slug?: string;
 }) =>
   callSuperTenant<SuperTenant>({
     action: "create_tenant",
     payload,
+  }).then((value) => {
+    invalidateOptionCaches("tenants:");
+    return value;
   });
 
 export const updateTenant = async (payload: {
   id: string;
   name: string;
   access_code: string;
+  account_category?: "organization" | "district" | "individual";
+  plan_code?:
+    | "core"
+    | "growth"
+    | "starter"
+    | "scale"
+    | "enterprise"
+    | "individual_yearly"
+    | "individual_monthly";
   district_name?: string;
   district_slug?: string;
 }) =>
   callSuperTenant<SuperTenant>({
     action: "update_tenant",
     payload,
+  }).then((value) => {
+    invalidateOptionCaches("tenants:");
+    return value;
   });
 
 export const setTenantStatus = async (payload: {
@@ -169,6 +254,9 @@ export const setTenantStatus = async (payload: {
   callSuperTenant<SuperTenant>({
     action: "set_tenant_status",
     payload,
+  }).then((value) => {
+    invalidateOptionCaches("tenants:");
+    return value;
   });
 
 export const sendPrimaryAdminReset = async (payload: { tenant_id: string }) =>
@@ -186,11 +274,21 @@ export const setPrimaryAdmin = async (payload: {
     payload,
   });
 
-export const listDistricts = async (search = "") =>
-  callSuperTenant<SuperDistrict[]>({
-    action: "list_districts",
-    payload: { search },
-  });
+export const listDistricts = async (search = "") => {
+  const normalizedSearch = search.trim();
+  const cacheKey = `districts:${normalizedSearch.toLowerCase()}`;
+  const loader = () =>
+    callSuperTenant<SuperDistrict[]>({
+      action: "list_districts",
+      payload: { search: normalizedSearch },
+    });
+
+  if (!normalizedSearch) {
+    return withCachedOptions(cacheKey, loader);
+  }
+
+  return loader();
+};
 
 export const createDistrict = async (payload: {
   name: string;
@@ -206,6 +304,9 @@ export const createDistrict = async (payload: {
   callSuperTenant<SuperDistrict>({
     action: "create_district",
     payload,
+  }).then((value) => {
+    invalidateOptionCaches("districts:", "tenants:");
+    return value;
   });
 
 export const updateDistrict = async (payload: {
@@ -224,6 +325,9 @@ export const updateDistrict = async (payload: {
   callSuperTenant<SuperDistrict>({
     action: "update_district",
     payload,
+  }).then((value) => {
+    invalidateOptionCaches("districts:", "tenants:");
+    return value;
   });
 
 export const getDistrictDetails = async (districtId: string) =>

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,7 @@
   color-scheme: dark;
   color: #f9f9f7;
   background-color: #0c1016;
+  --page-bg: #0c1016;
   --surface: #131922;
   --surface-2: #1a2230;
   --border: rgba(255, 255, 255, 0.12);
@@ -30,6 +31,7 @@
   color-scheme: light;
   color: #000000;
   background-color: #f9f9f7;
+  --page-bg: #f9f9f7;
   --surface: #ffffff;
   --surface-2: #f1f3f0;
   --border: rgba(0, 0, 0, 0.08);
@@ -53,12 +55,16 @@ a:hover {
   text-decoration: underline;
 }
 
+html {
+  background-color: var(--page-bg);
+}
+
 body {
   margin: 0;
   display: flex;
   min-width: 320px;
   min-height: 100vh;
-  background-color: inherit;
+  background-color: var(--page-bg);
   color: inherit;
 }
 
@@ -66,6 +72,11 @@ html.auth-route-active,
 body.auth-route-active {
   background: #090c12;
   overflow: hidden;
+}
+
+html.marketing-route-active,
+body.marketing-route-active {
+  background: #090d14;
 }
 
 html[data-theme="light"].auth-route-active,
@@ -177,9 +188,21 @@ button:focus-visible {
   overflow: hidden;
 }
 
+.app-shell.route-shell-marketing {
+  margin: -2.5rem -2rem -3rem;
+  min-height: 100vh;
+  padding: 0;
+  overflow-x: hidden;
+  background: #090d14;
+}
+
 @media (max-width: 640px) {
   .app-shell.route-shell-auth {
     margin: -2.5rem -2rem 0;
+  }
+
+  .app-shell.route-shell-marketing {
+    margin: -2.5rem -2rem -3rem;
   }
 }
 

--- a/supabase/functions/admin-ops/index.ts
+++ b/supabase/functions/admin-ops/index.ts
@@ -373,20 +373,37 @@ serve(async (req) => {
 
     let checkoutDueHours = 72;
     let featureFlags = defaultFeatureFlags();
-    const tenantPolicyResult = await adminClient
+    let tenantPolicyResult = await adminClient
       .from("tenant_policies")
-      .select("checkout_due_hours, feature_flags")
+      .select("checkout_due_hours, account_category, plan_code, feature_flags")
       .eq("tenant_id", tenantId)
       .maybeSingle();
 
-    if (!tenantPolicyResult.error && tenantPolicyResult.data) {
-      if (typeof tenantPolicyResult.data.checkout_due_hours === "number") {
+    if (isMissingColumn(tenantPolicyResult.error, "feature_flags")) {
+      const fallbackTenantPolicyResult = await adminClient
+        .from("tenant_policies")
+        .select("checkout_due_hours, account_category, plan_code")
+        .eq("tenant_id", tenantId)
+        .maybeSingle();
+
+      tenantPolicyResult = {
+        data: fallbackTenantPolicyResult.data
+          ? { ...fallbackTenantPolicyResult.data, feature_flags: null }
+          : null,
+        error: fallbackTenantPolicyResult.error,
+      };
+    }
+
+    const tenantPolicy = tenantPolicyResult.data;
+
+    if (!tenantPolicyResult.error && tenantPolicy) {
+      if (typeof tenantPolicy.checkout_due_hours === "number") {
         checkoutDueHours = Math.min(
           720,
-          Math.max(1, Math.round(tenantPolicyResult.data.checkout_due_hours))
+          Math.max(1, Math.round(tenantPolicy.checkout_due_hours))
         );
       }
-      featureFlags = normalizeFeatureFlags(tenantPolicyResult.data.feature_flags);
+      featureFlags = normalizeFeatureFlags(tenantPolicy.feature_flags);
     }
 
     let tenantUpdates: RuntimeUpdateItem[] = [];
@@ -480,6 +497,15 @@ serve(async (req) => {
       return jsonResponse(200, {
         data: {
           checkout_due_hours: checkoutDueHours,
+          account_category:
+            tenantPolicy?.account_category === "individual"
+              ? "individual"
+              : tenantPolicy?.account_category === "district"
+                ? "district"
+                : tenantPolicy?.account_category === "organization"
+                  ? "organization"
+                  : null,
+          plan_code: tenantPolicy?.plan_code ?? null,
           feature_flags: featureFlags,
         },
       });
@@ -511,11 +537,28 @@ serve(async (req) => {
         updated_at: new Date().toISOString(),
       };
 
-      const { data, error } = await adminClient
+      let settingsResult = await adminClient
         .from("tenant_policies")
         .upsert(row, { onConflict: "tenant_id" })
-        .select("checkout_due_hours, feature_flags")
+        .select("checkout_due_hours, account_category, plan_code, feature_flags")
         .single();
+
+      if (isMissingColumn(settingsResult.error, "feature_flags")) {
+        const fallbackSettingsResult = await adminClient
+          .from("tenant_policies")
+          .upsert(row, { onConflict: "tenant_id" })
+          .select("checkout_due_hours, account_category, plan_code")
+          .single();
+
+        settingsResult = {
+          data: fallbackSettingsResult.data
+            ? { ...fallbackSettingsResult.data, feature_flags: null }
+            : null,
+          error: fallbackSettingsResult.error,
+        };
+      }
+
+      const { data, error } = settingsResult;
 
       if (error || !data) {
         return jsonResponse(400, { error: "Unable to save tenant settings." });
@@ -527,6 +570,15 @@ serve(async (req) => {
             typeof data.checkout_due_hours === "number"
               ? data.checkout_due_hours
               : checkoutDueHoursNext,
+          account_category:
+            data.account_category === "individual"
+              ? "individual"
+              : data.account_category === "district"
+                ? "district"
+                : data.account_category === "organization"
+                  ? "organization"
+                  : null,
+          plan_code: data.plan_code ?? null,
           feature_flags: normalizeFeatureFlags(data.feature_flags),
         },
       });

--- a/supabase/functions/district-handoff/index.ts
+++ b/supabase/functions/district-handoff/index.ts
@@ -216,7 +216,16 @@ serve(async (req) => {
       }
 
       if (!districtSlug) {
-        return jsonResponse(404, { error: "District not found" }, headers);
+        return jsonResponse(
+          200,
+          {
+            code: null,
+            district_slug: null,
+            role,
+            root_only: true,
+          },
+          headers
+        );
       }
 
       const code = randomCode();

--- a/supabase/functions/super-ops/index.ts
+++ b/supabase/functions/super-ops/index.ts
@@ -288,7 +288,10 @@ serve(async (req) => {
 
       if (error || !data) {
         const message = (error?.message ?? "").toLowerCase();
-        if (error?.code === "42703" && message.includes("feature_flags")) {
+        if (
+          error?.code === "42703" &&
+          (message.includes("feature_flags") || message.includes("account_category") || message.includes("plan_code"))
+        ) {
           const { data: fallbackData, error: fallbackError } = await adminClient
             .from("tenant_policies")
             .upsert(

--- a/supabase/functions/super-tenant-mutate/index.ts
+++ b/supabase/functions/super-tenant-mutate/index.ts
@@ -29,6 +29,16 @@ type TenantRow = {
 type TenantPolicyRow = {
   tenant_id: string;
   checkout_due_hours: number | null;
+  account_category?: "organization" | "district" | "individual" | null;
+  plan_code?:
+    | "core"
+    | "growth"
+    | "starter"
+    | "scale"
+    | "enterprise"
+    | "individual_yearly"
+    | "individual_monthly"
+    | null;
   feature_flags: Record<string, unknown> | null;
 };
 
@@ -81,6 +91,11 @@ const isMissingDistrictIdColumn = (error: PgError | null | undefined) =>
   !!error &&
   error.code === "42703" &&
   (error.message ?? "").toLowerCase().includes("district_id");
+
+const isMissingFeatureFlagsColumn = (error: PgError | null | undefined) =>
+  !!error &&
+  error.code === "42703" &&
+  (error.message ?? "").toLowerCase().includes("feature_flags");
 
 const isMissingDistrictsTable = (error: PgError | null | undefined) =>
   !!error &&
@@ -148,6 +163,29 @@ const resolveResetRedirectTo = (req: Request) => {
 
 const isValidStatus = (value: unknown): value is "active" | "suspended" | "archived" =>
   value === "active" || value === "suspended" || value === "archived";
+
+const isValidTenantAccountCategory = (
+  value: unknown
+): value is "organization" | "district" | "individual" =>
+  value === "organization" || value === "district" || value === "individual";
+
+const isValidTenantPlanCode = (
+  value: unknown
+): value is
+  | "core"
+  | "growth"
+  | "starter"
+  | "scale"
+  | "enterprise"
+  | "individual_yearly"
+  | "individual_monthly" =>
+  value === "core" ||
+  value === "growth" ||
+  value === "starter" ||
+  value === "scale" ||
+  value === "enterprise" ||
+  value === "individual_yearly" ||
+  value === "individual_monthly";
 
 const verifySuperPassword = async (
   supabaseUrl: string,
@@ -376,18 +414,34 @@ serve(async (req) => {
           rows.map((row) => row.district_id).filter((value): value is string => !!value)
         )
       );
-      const [profileRowsResult, policyRowsResult, districtRowsResult] = await Promise.all([
+      const [profileRowsResult, rawPolicyRowsResult, districtRowsResult] = await Promise.all([
         ids.length
           ? adminClient.from("profiles").select("id, auth_email").in("id", ids)
           : Promise.resolve({ data: [], error: null }),
         adminClient
           .from("tenant_policies")
-          .select("tenant_id, checkout_due_hours, feature_flags")
+          .select("tenant_id, checkout_due_hours, account_category, plan_code, feature_flags")
           .in("tenant_id", tenantIds),
         districtIds.length
           ? adminClient.from("districts").select("id, name, slug").in("id", districtIds)
           : Promise.resolve({ data: [], error: null }),
       ]);
+
+      let policyRowsResult = rawPolicyRowsResult;
+      if (isMissingFeatureFlagsColumn(rawPolicyRowsResult.error as PgError)) {
+        const fallbackPolicyRowsResult = await adminClient
+          .from("tenant_policies")
+          .select("tenant_id, checkout_due_hours, account_category, plan_code")
+          .in("tenant_id", tenantIds);
+
+        policyRowsResult = {
+          data: (fallbackPolicyRowsResult.data ?? []).map((item) => ({
+            ...item,
+            feature_flags: null,
+          })),
+          error: fallbackPolicyRowsResult.error,
+        };
+      }
 
       const emailById = new Map(
         (
@@ -419,6 +473,13 @@ serve(async (req) => {
           typeof policyByTenant.get(row.id)?.checkout_due_hours === "number"
             ? policyByTenant.get(row.id)?.checkout_due_hours
             : 72,
+        account_category:
+          policyByTenant.get(row.id)?.account_category === "individual"
+            ? "individual"
+            : policyByTenant.get(row.id)?.account_category === "district"
+              ? "district"
+            : "organization",
+        plan_code: policyByTenant.get(row.id)?.plan_code ?? null,
         feature_flags:
           policyByTenant.get(row.id)?.feature_flags ?? defaultFeatureFlags(),
       }));
@@ -785,6 +846,10 @@ serve(async (req) => {
         typeof next.auth_email === "string" ? next.auth_email.trim().toLowerCase() : "";
       const password = typeof next.password === "string" ? next.password : "";
       const status = next.status;
+      const accountCategory = isValidTenantAccountCategory(next.account_category)
+        ? next.account_category
+        : "organization";
+      const planCode = isValidTenantPlanCode(next.plan_code) ? next.plan_code : null;
       const districtSlug =
         typeof next.district_slug === "string" ? normalizeDistrictSlug(next.district_slug) : "";
       const districtName =
@@ -806,6 +871,19 @@ serve(async (req) => {
         return jsonResponse(400, {
           error: "District name and slug must both be provided when assigning a district.",
         });
+      }
+      if (
+        (accountCategory === "individual" &&
+          !(!planCode || planCode === "individual_yearly" || planCode === "individual_monthly")) ||
+        (accountCategory === "district" &&
+          !(!planCode || planCode === "core" || planCode === "growth" || planCode === "enterprise")) ||
+        (accountCategory === "organization" &&
+          !(!planCode || planCode === "starter" || planCode === "scale" || planCode === "enterprise"))
+      ) {
+        return jsonResponse(400, { error: "Invalid plan for tenant account category." });
+      }
+      if (accountCategory === "individual" && (districtSlug || districtName)) {
+        return jsonResponse(400, { error: "Individual accounts cannot be assigned to a district." });
       }
 
       let districtId: string | null = null;
@@ -954,9 +1032,51 @@ serve(async (req) => {
         }
       }
 
+      let tenantPolicyResult = await adminClient
+        .from("tenant_policies")
+        .upsert(
+          {
+            tenant_id: data.id,
+            checkout_due_hours: 72,
+            account_category: accountCategory,
+            plan_code: planCode,
+            feature_flags: defaultFeatureFlags(),
+            updated_by: user.id,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: "tenant_id" }
+        );
+
+      if (isMissingFeatureFlagsColumn(tenantPolicyResult.error as PgError)) {
+        tenantPolicyResult = await adminClient
+          .from("tenant_policies")
+          .upsert(
+            {
+              tenant_id: data.id,
+              checkout_due_hours: 72,
+              account_category: accountCategory,
+              plan_code: planCode,
+              updated_by: user.id,
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: "tenant_id" }
+          );
+      }
+
+      if (tenantPolicyResult.error) {
+        await adminClient.auth.admin.deleteUser(userId);
+        if (createdProfileId) {
+          await adminClient.from("profiles").delete().eq("id", createdProfileId);
+        }
+        await adminClient.from("tenants").delete().eq("id", data.id);
+        return jsonResponse(400, { error: "Unable to create tenant policy." });
+      }
+
       await writeAudit("create_tenant", "tenant", data.id, {
         tenant_name: data.name,
         status: data.status,
+        account_category: accountCategory,
+        plan_code: planCode,
         district_slug: districtSlug || null,
         tenant_admin_email: authEmail,
       });
@@ -978,6 +1098,10 @@ serve(async (req) => {
       const name = typeof next.name === "string" ? next.name.trim() : "";
       const accessCode =
         typeof next.access_code === "string" ? next.access_code.trim() : "";
+      const accountCategory = isValidTenantAccountCategory(next.account_category)
+        ? next.account_category
+        : "organization";
+      const planCode = isValidTenantPlanCode(next.plan_code) ? next.plan_code : null;
       const districtSlug =
         typeof next.district_slug === "string" ? normalizeDistrictSlug(next.district_slug) : "";
       const districtName =
@@ -990,6 +1114,19 @@ serve(async (req) => {
         return jsonResponse(400, {
           error: "District name and slug must both be provided when assigning a district.",
         });
+      }
+      if (
+        (accountCategory === "individual" &&
+          !(!planCode || planCode === "individual_yearly" || planCode === "individual_monthly")) ||
+        (accountCategory === "district" &&
+          !(!planCode || planCode === "core" || planCode === "growth" || planCode === "enterprise")) ||
+        (accountCategory === "organization" &&
+          !(!planCode || planCode === "starter" || planCode === "scale" || planCode === "enterprise"))
+      ) {
+        return jsonResponse(400, { error: "Invalid plan for tenant account category." });
+      }
+      if (accountCategory === "individual" && (districtSlug || districtName)) {
+        return jsonResponse(400, { error: "Individual accounts cannot be assigned to a district." });
       }
 
       let districtId: string | null = null;
@@ -1017,8 +1154,27 @@ serve(async (req) => {
         return jsonResponse(400, { error: "Unable to update tenant." });
       }
 
+      const { error: policyError } = await adminClient
+        .from("tenant_policies")
+        .upsert(
+          {
+            tenant_id: id,
+            account_category: accountCategory,
+            plan_code: planCode,
+            updated_by: user.id,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: "tenant_id" }
+        );
+
+      if (policyError) {
+        return jsonResponse(400, { error: "Unable to update tenant plan details." });
+      }
+
       await writeAudit("update_tenant", "tenant", data.id, {
         tenant_name: data.name,
+        account_category: accountCategory,
+        plan_code: planCode,
         district_slug: districtSlug || null,
       });
 

--- a/supabase/sql/tenant_account_categories.sql
+++ b/supabase/sql/tenant_account_categories.sql
@@ -1,0 +1,32 @@
+alter table if exists public.tenant_policies
+  add column if not exists account_category text not null default 'organization';
+
+alter table if exists public.tenant_policies
+  add column if not exists plan_code text null;
+
+alter table if exists public.tenant_policies
+  drop constraint if exists tenant_policies_account_category_check;
+
+alter table if exists public.tenant_policies
+  add constraint tenant_policies_account_category_check
+  check (account_category in ('organization', 'individual'));
+
+alter table if exists public.tenant_policies
+  drop constraint if exists tenant_policies_plan_code_check;
+
+alter table if exists public.tenant_policies
+  add constraint tenant_policies_plan_code_check
+  check (
+    plan_code in (
+      'starter',
+      'scale',
+      'enterprise',
+      'individual_yearly',
+      'individual_monthly'
+    )
+    or plan_code is null
+  );
+
+update public.tenant_policies
+set account_category = coalesce(account_category, 'organization')
+where account_category is null;

--- a/supabase/sql/tenant_account_categories_v2.sql
+++ b/supabase/sql/tenant_account_categories_v2.sql
@@ -1,0 +1,24 @@
+alter table public.tenant_policies
+  drop constraint if exists tenant_policies_account_category_check;
+
+alter table public.tenant_policies
+  add constraint tenant_policies_account_category_check
+  check (account_category in ('organization', 'district', 'individual'));
+
+alter table public.tenant_policies
+  drop constraint if exists tenant_policies_plan_code_check;
+
+alter table public.tenant_policies
+  add constraint tenant_policies_plan_code_check
+  check (
+    plan_code in (
+      'core',
+      'growth',
+      'starter',
+      'scale',
+      'enterprise',
+      'individual_yearly',
+      'individual_monthly'
+    )
+    or plan_code is null
+  );


### PR DESCRIPTION
- add tenant-level account category and plan support across super-admin and tenant-admin surfaces, including district-specific plan options and legacy-schema-safe fallbacks in admin functions
- fix district/no-district admin handoff behavior and related tenant policy read/write issues in super-tenant, super-ops, admin-ops, and district-handoff flows
- promote the new landing page as the default public home while retaining the legacy landing page, refresh pricing to the new structure, and update marketing/auth surfaces without changing the established visual language
- tighten mobile route chrome/background handling, auth/mobile overflow behavior, and landing/pricing browser-fill colors across Safari routes
- reduce request churn by making notification/admin polling visibility-aware, caching super-admin tenant and district option loads, and gating public route prefetching on visibility and slow-connection signals
- keep local CI green by running env parity, build, performance budget/image/report, security gate, and Playwright E2E checks before commit