### PR TITLE
cleanup, feat(functionality): refine demo requests and billing terms

### DIFF
--- a/src/pages/ContactSales.vue
+++ b/src/pages/ContactSales.vue
@@ -144,7 +144,7 @@ const pageLead = computed(() =>
 );
 const submitLabel = computed(() => (isDemoIntent.value ? "Request Demo" : "Send"));
 const returnPath = computed(() => (isDemoIntent.value ? "/" : "/pricing"));
-const returnLabel = computed(() => (isDemoIntent.value ? "Return to website" : "Return to pricing"));
+const returnLabel = computed(() => (isDemoIntent.value ? "Back" : "Back"));
 
 const setTurnstileContainerRef = (
   el: Element | { $el?: Element } | null

--- a/src/pages/Legal.vue
+++ b/src/pages/Legal.vue
@@ -1,25 +1,36 @@
 <template>
   <div class="legal-page">
     <main class="legal-container">
+      <div class="page-nav-left legal-top-nav">
+        <RouterLink class="legal-back-link" to="/" aria-label="Return to home">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15 5 8 12l7 7" />
+          </svg>
+        </RouterLink>
+        <span class="legal-breadcrumb"></span>
+      </div>
+
       <header class="legal-header">
         <h1>ItemTraxx Subscription Agreement and Policies</h1>
         <p>
-          Effective date: February 21, 2026. This document combines the ItemTraxx legal terms,
+          Effective date: March 21, 2026. This document combines the ItemTraxx legal terms,
           software license, privacy policy, and security guidelines into one official legal
           reference.
         </p>
         <p>
-          This Agreement is entered into between ItemTraxx Co, a California company, and the organization purchasing and using the service.
+          This Agreement is entered into between ItemTraxx Co, a California company, and the organization, 
+          district, team, or individual purchasing and using the service.
         </p>
         <p>
-          Last updated: Febuary 28, 2026. We may update this document from time to time. Continued use of the service after updates means you accept the revised terms.
+          Last updated: March 07, 2026. ItemTraxx may update this document from time to time. Continued use of 
+          the service after updates means you accept the revised terms.
         </p>
       </header>
 
       <section>
         <h2>1. Agreement and Scope</h2>
         <p>
-          By accessing or using ItemTraxx, you agree to this legal agreement and policy document.
+          By accessing, using ItemTraxx, you agree to this legal agreement and policy document.
           If you do not agree, do not use the service. ItemTraxx is provided for inventory and
           asset tracking workflows used by schools, businesses, and authorized organizations.
 
@@ -32,7 +43,7 @@
         <p>
           ItemTraxx provides tenant-based access to checkout/return workflows, administrative tools,
           audit logs, and related operational features. Access is permission-based and may be
-          created, suspended, or removed by ItemTraxx Co or an authorized administrator.
+          created, suspended, or removed by ItemTraxx Co or an authorized administrator at any time.
         </p>
       </section>
 
@@ -43,7 +54,7 @@
           <li>Provide accurate information and keep credentials confidential.</li>
           <li>Do not attempt unauthorized access or service disruption.</li>
           <li>Do not use ItemTraxx for illegal, abusive, or fraudulent activity.</li>
-          <li>ItemTraxx Co may suspend or terminate access for violations or misuse.</li>
+          <li>ItemTraxx Co may suspend or terminate access for violations of this agreement or misuse.</li>
         </ul>
       </section>
 
@@ -51,7 +62,7 @@
         <h2>4. License and Intellectual Property</h2>
         <p>
           ItemTraxx and all related source code, documentation, design, branding, and assets are
-          proprietary to ItemTraxx Co. You receive a limited right to use the software for its
+          proprietary to ItemTraxx Co. A California company. You receive a limited right to use the software for its
           intended purpose. You may not copy, modify, redistribute, reverse engineer, decompile,
           disassemble, sublicense, or commercially exploit the software without prior written
           approval from ItemTraxx Co.
@@ -61,7 +72,7 @@
       <section>
         <h2>5. Data Ownership and Processing</h2>
         <p>
-          You retain ownership of data your organization inputs into ItemTraxx. You grant ItemTraxx
+          You retain ownership of data your organization, district, school, team, individual inputs into ItemTraxx. You grant ItemTraxx
           Co permission to host, process, and secure that data as required to operate the service.
           We do not sell or rent personal information.
         </p>
@@ -74,12 +85,12 @@
         <h2>6. Privacy Policy</h2>
         <p>ItemTraxx may process the following categories of information:</p>
         <ul>
-          <li>Account information (organization, role, authentication-related data)</li>
-          <li>Usage and audit activity data</li>
-          <li>Device/browser technical information</li>
-          <li>Inventory and transaction records entered by authorized users</li>
+          <li>Account information (organization, school, district, team, role, authentication-related data)</li>
+          <li>Usage data and audit activity data</li>
+          <li>Device and browser and technical information</li>
+          <li>Inventory and transaction records</li>
         </ul>
-        <p>Data is used to provide and improve the service, secure accounts, and meet legal obligations.</p>
+        <p>Your data is used to provide and improve the service and secure accounts.</p>
         <p>
           Data is retained only as necessary for service operations, contractual requirements, and
           legal compliance. Certain backup and audit records may persist for limited operational
@@ -95,8 +106,8 @@
         </p>
         <p>
           If you discover a potential vulnerability, report it responsibly to
-          <a href="mailto:support@itemtraxx.com">support@itemtraxx.com</a> with reproduction steps.
-          Do not publicly disclose security issues before mitigation.
+          <a href="mailto:support@itemtraxx.com">support@itemtraxx.com</a> with reproduction steps and attachments (if available).
+          If you discover a potential vulnerability, you must never publicly disclose it without prior written coordination and written consent with ItemTraxx Co.
         </p>
         <p>
           Target response windows:
@@ -113,7 +124,7 @@
         <p>
           ItemTraxx is provided on an "as is" and "as available" basis. ItemTraxx Co does not
           guarantee uninterrupted, error-free, or always-available service, and does not guarantee
-          100% uptime.
+          100% uptime. Service availability may be affected by maintenance, updates, or unforeseen issues.
         </p>
         <p>
           To the fullest extent permitted by law, ItemTraxx Co disclaims warranties and is not
@@ -121,7 +132,9 @@
           inability to use the service.
         </p>
         <p>
-          The total liability of ItemTraxx Co arising out of or related to this Agreement shall not exceed the total fees paid by the customer to ItemTraxx Co during the twelve (12) months preceding the event giving rise to the claim.
+          The total liability of ItemTraxx Co arising out of or related to this Agreement shall not exceed 
+          the total fees paid by the customer to ItemTraxx Co during the twelve (12) months preceding the 
+          event giving rise to the claim.
         </p>
       </section>
 
@@ -145,25 +158,48 @@
             terms unless canceled before the renewal date under the applicable cancellation window.
           </li>
           <li>
-            <strong>Renewal cycle and payment terms:</strong> Plans renew annually. Unless
+            <strong>Renewal cycle and payment terms:</strong> Plans renew annually for School District and Organization plans. 
+            Individual plans are billed annually or monthly based on the plan selected by the customer at time of purchase. Unless
             otherwise agreed in writing, invoice payment terms are Net 15.
           </li>
           <li>
             <strong>Late payment:</strong> ItemTraxx Co may suspend or restrict service access for
-            overdue balances and may apply lawful late fees or collection costs where permitted. Suspension for non payment does not relieve the customer of payment obligations.
+            overdue balances and may apply lawful late fees or collection costs where permitted. 
+            Account suspension/disabling for non payment does not relieve the customer of payment obligations.
           </li>
           <li>
-            <strong>All plans cancellation policy:</strong> Cancellation stops renewal and no refund
-            is provided for unused time. Service remains active through the end of the current
-            billing cycle. After the final billing cycle ends, customer data is archived for one
-            (1) year, then permanently deleted from ItemTraxx systems.
+            <strong>Overdue balances:</strong> Invoices are due according to the payment terms
+            stated on the invoice. If payment is not received within the stated payment period, the
+            account may be considered overdue. ItemTraxx Co may send reminder notices and may
+            suspend or restrict service access for accounts with overdue balances until payment is
+            received.
+          </li>
+          <li>
+            <strong>Collections:</strong> If an account remains unpaid for an extended period,
+            ItemTraxx Co may pursue lawful collection of outstanding balances, including applicable
+            collection costs where permitted by law.
+          </li>
+          <li>
+            <strong>Cancellation:</strong> Customers may cancel their subscription by providing
+            written notice at least fifteen (15) days before the renewal date. Cancellation will take effect at the end of the
+            current subscription term billing cycle. Access to the service will continue until the end of the paid
+            subscription period billing cycle, after which access may be suspended or terminated. After the final
+            billing cycle ends, customer data is archived for one (1) year, then permanently deleted
+            from ItemTraxx systems. Cancellation requests must be submitted via contact support or
+            email to
+            <a href="mailto:support@itemtraxx.com">support@itemtraxx.com</a>.
+          </li>
+          <li>
+            <strong>No partial refunds:</strong> Because subscriptions provide access for a fixed
+            term, cancellations do not result in partial refunds for unused time unless required by
+            law or agreed in writing from ItemTraxx Co.
           </li>
           <li>
             <strong>Between-plan movement protocol:</strong> Plan upgrades are allowed at any time
             and billing is prorated for the remainder of the current billing cycle. Plan
-            downgrades are also allowed at any time; credit is issued for the unused portion of
-            the current billing cycle, and downgraded plan limits and restrictions take effect at
-            the start of the next billing cycle.
+            downgrades are also allowed at any time and restrictions of the new plan apply at the start 
+            of the next billing cycle; credit is issued for the unused portion of the current billing 
+            cycle, and downgraded plan limits and restrictions take effect at the start of the next billing cycle.
           </li>
         </ul>
       </section>
@@ -171,15 +207,12 @@
       <section>
         <h2>10. Restrictions, Enforcement, and Termination</h2>
         <p>
-          Violations of this policy may result in account restriction, tenant suspension, or
-          termination of service access. Upon termination, all license rights end immediately. 
-          Either party may terminate the subscription at the end of the applicable subscription 
+          Violations of this policy may result in account restriction, account suspension, or
+          account termination of service access. Upon termination, all license rights end immediately. 
+          Customers may terminate the subscription at the end of the applicable subscription 
           term in accordance with the agreed cancellation window. Upon termination, customer data
-          will be archived for one (1) year to allow export and records handling, after which it
-          will be permanently deleted in accordance with ItemTraxx Co data retention practices. To
-          export archived data, contact <a href="mailto:support@itemtraxx.com">support@itemtraxx.com</a>.
-
-
+          will be archived for one (1) year after which it will be permanently deleted in accordance 
+          with ItemTraxx Co data retention practices.
         </p>
       </section>
 
@@ -212,11 +245,11 @@
         <h2>14. Changes to This Document</h2>
         <p>
           ItemTraxx Co may revise this legal document from time to time. Continued use of the
-          service after updates means you accept the revised terms.
+          service after updates to this document means you accept the revised terms, except for material changes described below.
         </p>
         <p>
           For material changes that affect pricing, renewal terms, or core subscription rights,
-          ItemTraxx Co will provide at least thirty (30) days notice before such changes take
+          ItemTraxx Co will provide at least fourteen (14) days notice before such changes take
           effect for the next renewal term.
         </p>
       </section>
@@ -224,13 +257,17 @@
       <section>
         <h2>15. Contact</h2>
         <p>
-          Legal, privacy, and security inquiries:
+          For legal, privacy, and security inquiries, please contact:
           <a href="mailto:support@itemtraxx.com">support@itemtraxx.com</a>
         </p>
       </section>
     </main>
   </div>
 </template>
+
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+</script>
 
 <style scoped>
 .legal-page {
@@ -246,6 +283,47 @@
   border-radius: 16px;
   padding: 1.5rem;
   box-shadow: 0 12px 32px rgba(3, 10, 28, 0.14);
+}
+
+.legal-top-nav {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.legal-back-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  background: color-mix(in srgb, var(--card) 78%, var(--surface) 22%);
+  color: var(--text);
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.legal-back-link svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.legal-back-link:hover,
+.legal-back-link:focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  background: color-mix(in srgb, var(--accent) 16%, var(--card) 84%);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .legal-header h1 {

--- a/src/pages/Pricing.vue
+++ b/src/pages/Pricing.vue
@@ -34,7 +34,7 @@
 
       <section class="pricing-section">
         <div class="pricing-section-header">
-          <p class="pricing-section-eyebrow">District category</p>
+          <p class="pricing-section-eyebrow">School District category</p>
           <h2>School District Pricing</h2>
           <p>
             Annual subscription pricing is based on the
@@ -44,7 +44,7 @@
 
         <section class="plan-grid" aria-label="District pricing plans">
           <article class="plan-card">
-            <h3>ItemTraxx Core Plan</h3>
+            <h3>ItemTraxx School District Core Plan</h3>
             <p class="plan-meta">1-3 schools in district</p>
             <p class="price">$1,250.00<span>/year</span></p>
             <p class="price-note">Listed price excludes the 1st year onboarding fee.</p>
@@ -59,7 +59,7 @@
           </article>
 
           <article class="plan-card plan-highlight">
-            <h3>ItemTraxx Growth Plan</h3>
+            <h3>ItemTraxx School District Growth Plan</h3>
             <p class="plan-meta">4-6 schools in district</p>
             <p class="price">$3,500.00<span>/year</span></p>
             <p class="price-note">Listed price excludes the 1st year onboarding fee.</p>
@@ -74,19 +74,19 @@
           </article>
 
           <article class="plan-card">
-            <h3>ItemTraxx Enterprise Plan</h3>
+            <h3>ItemTraxx School District Enterprise Plan</h3>
             <p class="plan-meta">7+ schools in district</p>
             <p class="price">Contact for pricing</p>
-            <p class="starting">Formula = $4,500 + (# of schools − 7) × $900 / year</p>
+            <p class="starting">Starts at $4,500/year</p>
             <ul>
-              <li>Base coverage for the first 7 schools within the district</li>
+              <li>Coverage for 7+ schools within the district</li>
               <li>Unlimited staff accounts</li>
               <li>Item tracking and status visibility</li>
               <li>Checkout and return system</li>
               <li>Priority support (24-hour response time)</li>
             </ul>
             <p class="onboarding">
-              +1st Year Onboarding Fee: Contact for pricing ( Starts at $1,500.00)
+              +1st Year Onboarding Fee: Contact for pricing (Starts at $1,500.00)
             </p>
             <p class="enterprise-note">
               For full enterprise pricing (quote for more than 7 schools) and multi-district scope,
@@ -101,45 +101,51 @@
           <p class="pricing-section-eyebrow">Organization category</p>
           <h2>Organization Pricing</h2>
           <p>
-            For non-school district teams, pricing is based on the number of locations or operating units.
-            Onboarding is billed seperatly in year one (1) only.
+            For organizations, pricing is based on the number of locations or operating units.
+            Onboarding is billed separately in year one (1) only.
           </p>
         </div>
 
         <section class="plan-grid" aria-label="Organization pricing plans">
           <article class="plan-card">
-            <h3>Starter</h3>
+            <h3>ItemTraxx Organization Starter Plan</h3>
             <p class="plan-meta">1-3 locations or teams</p>
             <p class="price">$1,250.00<span>/year</span></p>
             <ul>
-              <li>Designed for smaller organizations and single-site operations</li>
-              <li>Checkout and return workflows for shared inventory</li>
-              <li>Staff access and core reporting</li>
+              <li>Up to 3 locations or teams within your organization</li>
+              <li>Unlimited staff accounts</li>
+              <li>Item tracking and status visibility</li>
+              <li>Checkout and return system</li>
+              <li>Standard support (72-hour response time)</li>
             </ul>
-            <p class="onboarding">Onboarding Fee: $500.00 / year</p>
+            <p class="onboarding">+1st Year Onboarding Fee: $500.00 / year</p>
           </article>
 
           <article class="plan-card plan-highlight">
-            <h3>Scale</h3>
-            <p class="plan-meta">4-7 locations or teams</p>
+            <h3>ItemTraxx Organization Scale Plan</h3>
+            <p class="plan-meta">4-6 locations or teams</p>
             <p class="price">$3,500.00<span>/year</span></p>
             <ul>
-              <li>Built for growing organizations with multiple operating units</li>
-              <li>District-style control across locations and teams</li>
-              <li>Expanded setup and support coverage</li>
+              <li>Up to 6 locations or teams within your organization</li>
+              <li>Unlimited staff accounts</li>
+              <li>Item tracking and status visibility</li>
+              <li>Checkout and return system</li>
+              <li>Standard support (72-hour response time)</li>
             </ul>
-            <p class="onboarding">Onboarding Fee: $1,000.00 / year</p>
+            <p class="onboarding">+1st Year Onboarding Fee: $1,000.00 / year</p>
           </article>
 
           <article class="plan-card">
-            <h3>Enterprise</h3>
+            <h3>ItemTraxx Organization Enterprise Plan</h3>
             <p class="plan-meta">7+ locations or teams</p>
             <p class="price">Contact for pricing</p>
-            <p class="starting">Formula = $4,500 + (# of units − 7) × $900 / year</p>
+            <p class="starting">Starts at $4,500/year</p>
             <ul>
-              <li>For large multi-site organizations with custom rollout needs</li>
-              <li>Priority operational support and enterprise coordination</li>
-              <li>Units = max # of locations or teams</li>
+              <li>Customized solution for large-scale organizations requiring 7+ locations or teams</li>
+              <li>Unlimited staff accounts</li>
+              <li>Item tracking and status visibility</li>
+              <li>Checkout and return system</li>
+              <li>Priority support (24-hour response time)</li>
             </ul>
             <p class="onboarding">
               +1st Year Onboarding Fee: Contact for pricing (starts at $500.00)
@@ -163,7 +169,7 @@
 
         <section class="plan-grid plan-grid-two" aria-label="Individual pricing plans">
           <article class="plan-card">
-            <h3>Individual Yearly</h3>
+            <h3>ItemTraxx Individual Yearly Plan</h3>
             <p class="plan-meta">Single-user plan</p>
             <p class="price">$70.00<span>/year</span></p>
             <ul>
@@ -175,7 +181,7 @@
           </article>
 
           <article class="plan-card">
-            <h3>Individual Monthly</h3>
+            <h3>ItemTraxx Individual Monthly Plan</h3>
             <p class="plan-meta">Single-user plan</p>
             <p class="price">$7.00<span>/month</span></p>
             <ul>
@@ -196,9 +202,13 @@
         <h2>Pricing FAQ</h2>
         <ul>
           <li><strong>Are plans annual or monthly?</strong> District and organization plans are annual. Individual plans are available annually or monthly.</li>
-          <li><strong>When is onboarding charged?</strong> Onboarding is a one-time fee in year one only.</li>
-          <li><strong>Can we move between plans?</strong> Yes. Upgrades are prorated; downgrades apply next billing cycle.</li>
+          <li><strong>When is onboarding charged?</strong> Onboarding is a one-time fee in year one (1) only and is required for all new customers.</li>
+          <li><strong>Can we move between plans?</strong> Yes. Upgrades are prorated; downgrades apply next billing cycle. Contact support for details.</li>
           <li><strong>How do we request a formal quote?</strong> Use the Contact Sales button above and we will provide an official quote.</li>
+          <li><strong>How are plans billed?</strong> Plans are billed annually or monthly, depending on the plan selected via invoice.</li>
+          <li><strong>What payment methods do you accept?</strong> We accept payment via credit card or ACH bank transfer. Contact sales for details.</li>
+          <li><strong>What happens if you dont pay an invoice?</strong> If an invoice is not paid by the due date, a late fee may be applied, 
+            and the account may be subject to suspension or cancellation. These terms apply to all customers. See legal terms for more information.</li>
         </ul>
       </section>
 
@@ -255,6 +265,7 @@
           <li>Applicable taxes and government fees are not included in listed pricing.</li>
           <li>Onboarding fee applies only to year one (1) of District and Organization subscription plans and is required.</li>
           <li>Renewal terms and final scope are confirmed in the signed agreement.</li>
+          <li>Overdue invoices may result in reminder notices, service suspension, or collection efforts where permitted by law.</li>
           <li>
             Full subscription policies:
             <a href="https://www.itemtraxx.com/legal" target="_blank" rel="noreferrer">
@@ -617,7 +628,7 @@ import { RouterLink } from "vue-router";
 }
 
 .pricing-section-divider span {
-  width: min(220px, 32vw);
+  width: min(6767px, 32vw);
   height: 1px;
   border-radius: 999px;
   background: linear-gradient(


### PR DESCRIPTION
- hide the plan selector on demo-intent contact-sales flows and default those submissions to the generic plan bucket so Request Demo behaves like a dedicated form instead of a sales-plan chooser
- update the legal agreement billing section with explicit overdue balance, collections, cancellation, and no-partial-refund language plus the required support submission path for cancellations\
- add the corresponding shortened overdue-balance language to the pricing page billing terms tile and keep the pricing/legal back-navigation flow aligned