### PR TITLE
fix(auth): harden district handoff bootstrap

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -207,10 +207,11 @@
         </a>
       </div>
     </div>
-    <div v-if="!auth.isInitialized" class="page">
-      <h1>bye bye 👋</h1>
-      <p>Please press Cmd+shift+R (macOS), or Ctrl+Shift+R (Windows) to finish signing out.</p>
-      <button type="button" class="button-primary" @click="reloadApp">Reload</button>
+    <div v-if="!auth.isInitialized" class="page auth-loading-page">
+      <div class="auth-loading-card">
+        <h1>Loading ItemTraxx</h1>
+        <p>Restoring your session and district context.</p>
+      </div>
     </div>
     <router-view v-else />
     <OnboardingModal

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   setSecondaryAuth,
   setTenantContext,
 } from "./store/authState";
+import { getDistrictState } from "./store/districtState";
 import {
   consumeDistrictSessionHandoff,
   initAuthListener,
@@ -159,11 +160,13 @@ const mountApp = () => {
 const bootstrap = async () => {
   const consumedDistrictHandoff = await consumeDistrictSessionHandoff();
   await initializeDistrictContext();
+  const districtContext = getDistrictState();
   const isE2ETestMode = import.meta.env.VITE_E2E_TEST_UTILS === "true";
-  const canMountFirst = isE2ETestMode || isPublicBootstrapPath();
+  const canMountFirst =
+    isE2ETestMode || isPublicBootstrapPath() || districtContext.isDistrictHost;
   if (canMountFirst) {
     // Avoid flashing the temporary logout screen during normal public-route bootstrap.
-    if (!isE2ETestMode) {
+    if (!isE2ETestMode && isPublicBootstrapPath()) {
       clearAuthState(true);
     }
     mountApp();

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -469,7 +469,12 @@ export const consumeDistrictSessionHandoff = async () => {
     return false;
   }
 
-  await clearLocalSession();
+  params.delete("itx_hc");
+  params.delete("itx_at");
+  params.delete("itx_rt");
+  const nextHash = params.toString();
+  const nextUrl = `${window.location.pathname}${window.location.search}${nextHash ? `#${nextHash}` : ""}`;
+  window.history.replaceState({}, document.title, nextUrl);
 
   let finalAccessToken = accessToken;
   let finalRefreshToken = refreshToken;
@@ -487,6 +492,12 @@ export const consumeDistrictSessionHandoff = async () => {
     });
 
     if (!result.ok || !result.data?.access_token || !result.data?.refresh_token) {
+      if (result.status === 410) {
+        const { data: sessionData } = await supabase.auth.getSession();
+        if (sessionData.session?.access_token && sessionData.session?.refresh_token) {
+          return false;
+        }
+      }
       throw new Error("Unable to complete district sign-in.");
     }
 
@@ -497,6 +508,8 @@ export const consumeDistrictSessionHandoff = async () => {
   if (!finalAccessToken || !finalRefreshToken) {
     throw new Error("Unable to complete district sign-in.");
   }
+
+  await clearLocalSession();
 
   const { data, error } = await supabase.auth.setSession({
     access_token: finalAccessToken,
@@ -516,13 +529,6 @@ export const consumeDistrictSessionHandoff = async () => {
   } catch {
     // Ignore sessionStorage failures.
   }
-
-  params.delete("itx_hc");
-  params.delete("itx_at");
-  params.delete("itx_rt");
-  const nextHash = params.toString();
-  const nextUrl = `${window.location.pathname}${window.location.search}${nextHash ? `#${nextHash}` : ""}`;
-  window.history.replaceState({}, document.title, nextUrl);
   return true;
 };
 

--- a/src/style.css
+++ b/src/style.css
@@ -232,6 +232,39 @@ button:focus-visible {
   margin: 0 auto;
 }
 
+.auth-loading-page {
+  min-height: 100vh;
+  max-width: none;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(25, 194, 168, 0.18), transparent 30%),
+    radial-gradient(circle at 82% 22%, rgba(30, 89, 214, 0.2), transparent 28%),
+    #090d14;
+}
+
+.auth-loading-card {
+  width: min(100%, 28rem);
+  border: 1px solid rgba(83, 214, 197, 0.2);
+  border-radius: 24px;
+  padding: 1.75rem 1.5rem;
+  background: rgba(11, 18, 31, 0.82);
+  box-shadow: 0 28px 56px rgba(0, 0, 0, 0.28);
+  text-align: center;
+}
+
+.auth-loading-card h1 {
+  margin: 0 0 0.65rem;
+  color: #f4f7fb;
+  font-size: clamp(1.8rem, 4vw, 2.35rem);
+}
+
+.auth-loading-card p {
+  margin: 0;
+  color: rgba(230, 236, 245, 0.72);
+}
+
 .admin-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/supabase/functions/district-handoff/index.ts
+++ b/supabase/functions/district-handoff/index.ts
@@ -107,10 +107,16 @@ serve(async (req) => {
         password,
       });
 
-      if (signIn.error || !signIn.data.user?.id) {
+      if (
+        signIn.error ||
+        !signIn.data.user?.id ||
+        !signIn.data.session?.access_token ||
+        !signIn.data.session?.refresh_token
+      ) {
         return jsonResponse(401, { error: "Invalid credentials" }, headers);
       }
       const user = signIn.data.user;
+      const session = signIn.data.session;
 
       const { data: district, error: districtError } = await adminClient
         .from("districts")
@@ -136,7 +142,8 @@ serve(async (req) => {
         user_id: user.id,
         district_slug: districtSlug,
         auth_email: authEmail,
-        password,
+        access_token: session.access_token,
+        refresh_token: session.refresh_token,
         expires_at: expiresAt,
       });
 
@@ -166,11 +173,17 @@ serve(async (req) => {
         password,
       });
 
-      if (signIn.error || !signIn.data.user?.id) {
+      if (
+        signIn.error ||
+        !signIn.data.user?.id ||
+        !signIn.data.session?.access_token ||
+        !signIn.data.session?.refresh_token
+      ) {
         return jsonResponse(401, { error: "Invalid credentials" }, headers);
       }
 
       const user = signIn.data.user;
+      const session = signIn.data.session;
       const { data: profile } = await adminClient
         .from("profiles")
         .select("role, tenant_id, district_id, is_active")
@@ -242,7 +255,8 @@ serve(async (req) => {
         user_id: user.id,
         district_slug: districtSlug,
         auth_email: email,
-        password,
+        access_token: session.access_token,
+        refresh_token: session.refresh_token,
         expires_at: expiresAt,
       });
 
@@ -267,38 +281,28 @@ serve(async (req) => {
       const codeHash = await sha256(code);
       const { data: row, error: selectError } = await adminClient
         .from("district_session_handoffs")
-        .select("id, district_slug, auth_email, password, expires_at")
+        .select("id, district_slug, access_token, refresh_token, expires_at")
         .eq("code_hash", codeHash)
         .single();
 
       if (
         selectError ||
         !row?.id ||
-        !row.auth_email ||
-        !row.password ||
+        !row.access_token ||
+        !row.refresh_token ||
         !row.expires_at ||
         new Date(row.expires_at).getTime() <= Date.now()
       ) {
         return jsonResponse(410, { error: "Handoff expired" }, headers);
       }
 
-      const userClient = createClient(supabaseUrl, publishableKey, {
-        auth: { persistSession: false },
-      });
-      const signIn = await userClient.auth.signInWithPassword({
-        email: row.auth_email,
-        password: row.password,
-      });
-
-      if (signIn.error || !signIn.data.session?.access_token || !signIn.data.session?.refresh_token) {
-        return jsonResponse(401, { error: "Unable to complete sign-in" }, headers);
-      }
+      await adminClient.from("district_session_handoffs").delete().eq("id", row.id);
 
       return jsonResponse(
         200,
         {
-          access_token: signIn.data.session.access_token,
-          refresh_token: signIn.data.session.refresh_token,
+          access_token: row.access_token,
+          refresh_token: row.refresh_token,
           district_slug: row.district_slug,
         },
         headers

--- a/supabase/sql/district_session_handoffs_v3.sql
+++ b/supabase/sql/district_session_handoffs_v3.sql
@@ -1,0 +1,10 @@
+delete from public.district_session_handoffs;
+
+alter table if exists public.district_session_handoffs
+  drop column if exists password;
+
+alter table if exists public.district_session_handoffs
+  alter column access_token set not null;
+
+alter table if exists public.district_session_handoffs
+  alter column refresh_token set not null;


### PR DESCRIPTION
- remove plaintext password persistence from district handoff records and add a cleanup migration to drop the password column
- switch district handoff consume back to one-time token delivery using stored access/refresh tokens only
- mount district routes immediately during bootstrap so refreshes show a loading state instead of a blank page
- clear handoff hash params before consume and tolerate spent handoff codes when a valid local session already exists on reload
- keep local verification green with build and bundle budget checks