### PR TITLE
fix(router): allow district route bootstrap during auth init

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -438,7 +438,7 @@ router.beforeEach((to) => {
 
   const auth = getAuthState();
   if (!auth.isInitialized) {
-    return false;
+    return true;
   }
 
   if (


### PR DESCRIPTION
- stop cancelling initial protected-route navigation while auth state is still bootstrapping
- prevent district-host redirects from mounting the app shell without route content
- keep local verification green with build and bundle budget checks