### PR TITLE
fix(ui): keep top banners in flow across public pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
       'with-top-banners': hasTopBanners,
       'route-shell-auth': isFullBleedRoute,
       'route-shell-marketing': isMarketingFullBleedRoute,
+      'route-shell-banner-bleed': isBannerBleedRoute,
     }"
     :style="appShellStyle"
   >
@@ -113,6 +114,7 @@
     </div>
     <div
       v-if="incidentBanner && showIncidentBanner"
+      ref="incidentBannerRef"
       class="broadcast-banner incident-banner"
       :class="incidentBanner.level === 'down' ? 'broadcast-critical' : 'broadcast-warning'"
       :style="incidentBannerStyle"
@@ -279,8 +281,10 @@ const incidentBanner = ref<IncidentBanner | null>(null);
 const dismissedIncidentId = ref(localStorage.getItem("itemtraxx-incident-dismissed") || "");
 const maintenanceBannerRef = ref<HTMLElement | null>(null);
 const broadcastBannerRef = ref<HTMLElement | null>(null);
+const incidentBannerRef = ref<HTMLElement | null>(null);
 const maintenanceBannerHeight = ref(0);
 const broadcastBannerHeight = ref(0);
+const incidentBannerHeight = ref(0);
 const maintenanceEnabled = ref(false);
 const maintenanceMessage = ref("Maintenance currentlyin progress.");
 const killSwitchEnabled = ref(false);
@@ -334,6 +338,13 @@ const isFullBleedRoute = computed(
 );
 const isMarketingFullBleedRoute = computed(
   () => route.path === "/" || route.path === "/landing-new"
+);
+const isBannerBleedRoute = computed(
+  () =>
+    route.path === "/legal" ||
+    route.path === "/pricing" ||
+    route.path === "/contact-sales" ||
+    route.path === "/contact-support"
 );
 const isDarkChromeRoute = computed(
   () => route.path === "/" || route.path === "/landing-new" || route.path === "/pricing"
@@ -428,9 +439,13 @@ const incidentSlaLine = computed(() => {
   if (Number.isNaN(checked.getTime())) return slaTarget;
   return `${slaTarget} Last checked ${checked.toLocaleTimeString()}.`;
 });
-const hasTopBanners = computed(() => showMaintenanceBanner.value || (showBroadcast.value && !!activeBroadcast.value));
+const hasTopBanners = computed(() =>
+  showMaintenanceBanner.value ||
+  (showBroadcast.value && !!activeBroadcast.value) ||
+  showIncidentBanner.value
+);
 const topOffsetPx = computed(() => {
-  const total = maintenanceBannerHeight.value + broadcastBannerHeight.value;
+  const total = maintenanceBannerHeight.value + broadcastBannerHeight.value + incidentBannerHeight.value;
   if (total <= 0) return "0px";
   return `${total}px`;
 });
@@ -463,10 +478,10 @@ const topMenuStyle = computed(() => ({
   top: `calc(1rem + ${topOffsetPx.value})`,
 }));
 const incidentBannerStyle = computed(() => ({
-  top: `calc(1rem + ${topOffsetPx.value})`,
+  top: "0px",
 }));
 const broadcastBannerStyle = computed(() => ({
-  top: showMaintenanceBanner.value ? `${maintenanceBannerHeight.value}px` : "0px",
+  top: "0px",
 }));
 const offlineQueueTooltip = computed(
   () =>
@@ -483,6 +498,9 @@ const measureTopBanners = () => {
     : 0;
   broadcastBannerHeight.value = showBroadcast.value && activeBroadcast.value
     ? (broadcastBannerRef.value?.offsetHeight ?? 0)
+    : 0;
+  incidentBannerHeight.value = showIncidentBanner.value && incidentBanner.value
+    ? (incidentBannerRef.value?.offsetHeight ?? 0)
     : 0;
 };
 

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -4,7 +4,7 @@
       <section class="login-story-panel">
         <header class="story-header">
           <div class="story-brand">ItemTraxx</div>
-          <RouterLink class="story-back-link" to="/">Back to website</RouterLink>
+          <RouterLink class="story-back-link" to="/">Back</RouterLink>
         </header>
 
         <div class="story-copy-wrap">

--- a/src/style.css
+++ b/src/style.css
@@ -178,10 +178,6 @@ button:focus-visible {
   text-align: left;
 }
 
-.app-shell.with-top-banners {
-  padding-top: var(--top-banner-offset);
-}
-
 .app-shell.route-shell-auth {
   margin: -2.5rem -2rem 0;
   min-height: 100vh;
@@ -196,6 +192,19 @@ button:focus-visible {
   background: #090d14;
 }
 
+.app-shell.route-shell-banner-bleed.with-top-banners {
+  margin-top: -2.5rem;
+}
+
+.app-shell.with-top-banners .pricing-shell {
+  margin-top: 0;
+  padding-top: 1.5rem;
+}
+
+.app-shell.with-top-banners .contact-sales-page {
+  padding-top: 0.5rem;
+}
+
 @media (max-width: 640px) {
   .app-shell.route-shell-auth {
     margin: -2.5rem -2rem 0;
@@ -203,6 +212,10 @@ button:focus-visible {
 
   .app-shell.route-shell-marketing {
     margin: -2.5rem -2rem -3rem;
+  }
+
+  .app-shell.with-top-banners .pricing-shell {
+    padding-top: 1.1rem;
   }
 }
 
@@ -587,10 +600,8 @@ textarea {
 }
 
 .maintenance-top-banner {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
   z-index: 1100;
   display: flex;
   align-items: center;
@@ -601,6 +612,13 @@ textarea {
   color: #fff5f5;
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
   font-size: 0.92rem;
+}
+
+.app-shell.route-shell-banner-bleed .maintenance-top-banner,
+.app-shell.route-shell-banner-bleed .broadcast-top-banner,
+.app-shell.route-shell-banner-bleed .incident-banner {
+  margin-left: -2rem;
+  margin-right: -2rem;
 }
 
 .maintenance-top-banner strong {
@@ -730,6 +748,13 @@ textarea {
   .maintenance-fullscreen .button-link,
   .maintenance-fullscreen .button-primary {
     width: 100%;
+  }
+
+  .app-shell.route-shell-banner-bleed .maintenance-top-banner,
+  .app-shell.route-shell-banner-bleed .broadcast-top-banner,
+  .app-shell.route-shell-banner-bleed .incident-banner {
+    margin-left: -2rem;
+    margin-right: -2rem;
   }
 }
 
@@ -863,9 +888,8 @@ textarea {
 }
 
 .broadcast-top-banner {
-  position: fixed;
-  left: 0;
-  right: 0;
+  position: sticky;
+  top: 0;
   z-index: 1100;
   display: flex;
   align-items: flex-start;
@@ -907,7 +931,15 @@ textarea {
 }
 
 .incident-banner {
-  top: 4.8rem;
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1095;
+  max-width: none;
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .broadcast-content {


### PR DESCRIPTION
- move maintenance, broadcast, and incident banners into sticky in-flow placement so public page headers stay accessible under alerts
- add route-specific shell handling for pricing, contact sales, contact support, and legal so banners render full-width without top or side gutters
- preserve landing page marketing shell behavior while avoiding overflow regressions on banner-enabled routes
- keep top menu and route progress offsets aligned with stacked banner heights
- include the login back-link copy update already staged in the working tree