### PR TITLE
update button labels and legal notes

### DIFF
--- a/src/components/PublicFooter.vue
+++ b/src/components/PublicFooter.vue
@@ -19,7 +19,7 @@
       </div>
       <div class="footer-column">
         <p class="footer-heading">Support</p>
-        <RouterLink to="/contact-support">Support</RouterLink>
+        <RouterLink to="/contact-support">Contact Support</RouterLink>
         <RouterLink to="/security">Security</RouterLink>
         <RouterLink to="/report-security-issue">Report Security Issue</RouterLink>
         <RouterLink to="/trust">Trust</RouterLink>

--- a/src/pages/ContactSales.vue
+++ b/src/pages/ContactSales.vue
@@ -92,7 +92,7 @@
           </button>
         </div>
         <p class="submit-legal-note">
-          By sending, you agree to <RouterLink to="/legal">Legal</RouterLink>.
+          By clicking Submit Sales Request, you agree to our <RouterLink to="/privacy">Privacy Policy</RouterLink> and <RouterLink to="/legal">Terms of Service</RouterLink>.
         </p>
       </form>
       <p v-if="error" class="error">{{ error }}</p>
@@ -146,7 +146,7 @@ const pageLead = computed(() =>
     ? "Send your demo request and our team will respond from support@itemtraxx.com to schedule next steps."
     : "Send your request and our team will respond from support@itemtraxx.com."
 );
-const submitLabel = computed(() => (isDemoIntent.value ? "Request Demo" : "Send"));
+const submitLabel = computed(() => (isDemoIntent.value ? "Request Demo" : "Submit Sales Request"));
 const returnPath = computed(() => (isDemoIntent.value ? "/" : "/pricing"));
 const returnLabel = computed(() => (isDemoIntent.value ? "Back" : "Back"));
 

--- a/src/pages/ContactSupport.vue
+++ b/src/pages/ContactSupport.vue
@@ -99,11 +99,11 @@
 
         <div class="form-actions">
           <button type="submit" class="button-primary" :disabled="isSending || !canSubmit">
-            {{ isSending ? "Sending..." : "Send" }}
+            {{ isSending ? "Sending..." : "Submit Support Request" }}
           </button>
         </div>
         <p class="submit-legal-note">
-          By sending, you agree to <RouterLink to="/legal">Legal</RouterLink>.
+          By clicking Submit Support Request, you agree to our <RouterLink to="/privacy">Privacy Policy</RouterLink> and <RouterLink to="/legal">Terms of Service</RouterLink>.
         </p>
       </form>
       <p v-if="error" class="error">{{ error }}</p>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -103,7 +103,9 @@
             </p>
 
             <p class="muted support-note">
-              Trouble signing in? Contact our support team from the top-right menu. By using this software, you agree to our
+              Trouble signing in? Contact our support team from the top-right menu for help.
+              <br />
+              By using this software, you agree to our
               <a :href="legalUrl" target="_blank" rel="noreferrer">legal terms and policies</a>.
             </p>
           </form>

--- a/src/pages/ReportSecurityIssuePage.vue
+++ b/src/pages/ReportSecurityIssuePage.vue
@@ -133,7 +133,7 @@
               </button>
             </div>
             <p class="security-report-legal-note">
-              By sending, you agree to <RouterLink to="/legal">Legal</RouterLink>.
+                        By clicking Send Security Report, you agree to our <RouterLink to="/privacy">Privacy Policy</RouterLink> and <RouterLink to="/legal">Terms of Service</RouterLink>.
             </p>
           </form>
 

--- a/src/pages/RequestDemoPage.vue
+++ b/src/pages/RequestDemoPage.vue
@@ -6,7 +6,7 @@
 
     <h1>Request a Demo</h1>
     <p class="muted">
-      Send a demo request and our team will follow up from support@itemtraxx.com to schedule next
+      Send a demo request and our team will follow up within 48 hours to schedule next
       steps.
     </p>
 
@@ -71,11 +71,11 @@
 
         <div class="form-actions">
           <button type="submit" class="button-primary" :disabled="isSending || !canSubmit">
-            {{ isSending ? "Sending..." : "Request Demo" }}
+            {{ isSending ? "Sending..." : "Send Demo Request" }}
           </button>
         </div>
         <p class="submit-legal-note">
-          By sending, you agree to <RouterLink to="/legal">Legal</RouterLink>.
+          By clicking Send Demo Request, you agree to our <RouterLink to="/privacy">Privacy Policy</RouterLink> and <RouterLink to="/legal">Terms of Service</RouterLink>.
         </p>
       </form>
       <p v-if="error" class="error">{{ error }}</p>


### PR DESCRIPTION
This pull request updates the language and legal notices on several public-facing forms and pages to improve clarity and ensure users are explicitly informed about the Privacy Policy and Terms of Service. Button labels and instructions have been made more specific, and legal consent statements have been updated for consistency across support, sales, demo, and security report forms.

**Legal notice and consent updates:**

* Updated legal consent statements on the sales, support, demo request, and security report forms to explicitly reference the Privacy Policy and Terms of Service, replacing previous generic "Legal" references. [[1]](diffhunk://#diff-e1aa65de30cd57e93e850ab68cc852cb85c56a0d4aa8fbdea6dd65c93a2f52d9L95-R95) [[2]](diffhunk://#diff-7b0826566a68b64cf1a3b61318b59e865ce35244b11ccbea7427bf0b857a248fL102-R106) [[3]](diffhunk://#diff-c20f96057df00f7eaa5cb701993fd6b15a4f391833d2342dabaf09c9b127f918L136-R136) [[4]](diffhunk://#diff-35d33bce100d31b191a881731e0d2f2df5b34344a2cbd56cef3298637739e374L74-R78)

**Button and link label improvements:**

* Changed button labels and related text to be more descriptive, such as "Submit Sales Request," "Submit Support Request," and "Send Demo Request," for improved clarity. [[1]](diffhunk://#diff-e1aa65de30cd57e93e850ab68cc852cb85c56a0d4aa8fbdea6dd65c93a2f52d9L149-R149) [[2]](diffhunk://#diff-7b0826566a68b64cf1a3b61318b59e865ce35244b11ccbea7427bf0b857a248fL102-R106) [[3]](diffhunk://#diff-35d33bce100d31b191a881731e0d2f2df5b34344a2cbd56cef3298637739e374L74-R78)
* Updated the "Support" link in the public footer to "Contact Support" for clarity.

**User guidance and copy changes:**

* Clarified the demo request page instructions to specify a 48-hour response window.
* Improved the login page's support note for better readability and separated the legal notice onto its own line.