### PR TITLE
update posthog-js to version 1.369.3

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -43,7 +43,8 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        # Avoid flaky native/CLI postinstall downloads during CI (for example `supabase` CLI).
+        run: npm ci --ignore-scripts
 
       - name: Verify env parity
         run: bash ./scripts/check-env-parity.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,9 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        # Avoid flaky native/CLI postinstall downloads during E2E runs (for example `supabase` CLI).
+        # Playwright browsers are installed explicitly in the next step.
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "jsbarcode": "^3.12.3",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
-        "posthog-js": "^1.369.2",
+        "posthog-js": "^1.369.3",
         "supabase": "2.92.1",
         "vue": "^3.5.32",
         "vue-router": "^4.6.4",
@@ -1503,9 +1503,9 @@
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.369.2",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.2.tgz",
-      "integrity": "sha512-PJqkqPCFnnbCZslH2jHSvXlasRqvke6YAsYPhPALy4zy2hldor8A0O2wIlpAefEJ7fVz6wR5ZbRJzQP6nwujyw==",
+      "version": "1.369.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.3.tgz",
+      "integrity": "sha512-Ywqvs4513PixR2TIA5O3GMEyK4F65uefwxPfsIUeHr9ruGylyXp00YJ4CEbp8U0DMzCkeF+LsMKVnHgN3pAXcA==",
       "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3485,9 +3485,9 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.369.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.2.tgz",
-      "integrity": "sha512-pY+SvNvRp3C2XW80h/jwVLTgoruK15C6klo9bYYoO6DCK9EbcwS6YzjgxBHx1dIN0XBZM3KWJPmuaSimU65HQQ==",
+      "version": "1.369.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.3.tgz",
+      "integrity": "sha512-t4vk8mgkSdhIYr8YDRdLG45uJYH58MC7bPL83lKTEeDgoejyXbJ1/G77GZB/aWVQDST055GkgjQtUtK5DiYGkg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -3496,7 +3496,7 @@
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
         "@posthog/core": "1.25.2",
-        "@posthog/types": "1.369.2",
+        "@posthog/types": "1.369.3",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsbarcode": "^3.12.3",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
-    "posthog-js": "^1.369.2",
+    "posthog-js": "^1.369.3",
     "supabase": "2.92.1",
     "vue": "^3.5.32",
     "vue-router": "^4.6.4",
@@ -50,8 +50,8 @@
     "typescript": "~6.0.3",
     "vite": "^8.0.8",
     "vue-tsc": "^3.2.6",
-    "zod-to-json-schema": "^3.25.2",
-    "wrangler": "^4.83.0"
+    "wrangler": "^4.83.0",
+    "zod-to-json-schema": "^3.25.2"
   },
   "overrides": {
     "tar": "^7.5.10",


### PR DESCRIPTION
This pull request makes minor dependency updates and a small adjustment to the `devDependencies` ordering in the `package.json` file.

Dependency updates:

* Upgraded `posthog-js` from version `1.369.2` to `1.369.3` to include the latest patch updates.

DevDependencies reordering:

* Swapped the order of `wrangler` and `zod-to-json-schema` in the `devDependencies` section for consistency, without changing their versions.

Summary generated by Copilot