### PR TITLE
refactor email branding to use new logo URLs

### DIFF
--- a/scripts/generate-email-previews.mjs
+++ b/scripts/generate-email-previews.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,11 +6,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const outDir = path.join(repoRoot, "tmp", "email-previews");
 
-const logoSource = path.join(repoRoot, "public", "brand", "logo-light.png");
-const logoFileName = "brand-logo.png";
-const logoUrl = `./${logoFileName}`;
 const passwordResetUrl = "https://itemtraxx.com/forgot-password";
 const contactSupportUrl = "https://itemtraxx.com/contact-support";
+const emailLogoUrl = "https://assets.itemtraxx.com/brand/logo-light.png";
 
 const escapeHtml = (value) =>
   String(value)
@@ -21,15 +19,13 @@ const escapeHtml = (value) =>
     .replaceAll("'", "&#39;");
 
 const brandHeader = () =>
-  [
-    `<img`,
-    ` src="${logoUrl}"`,
-    ` alt="ItemTraxx"`,
-    ` width="150"`,
-    ` height="50"`,
-    ` style="display:block;width:150px;height:50px;max-width:150px;border:0;outline:none;text-decoration:none;"`,
-    ` />`,
-  ].join("");
+  `<img
+                  src="${emailLogoUrl}"
+                  alt="ItemTraxx"
+                  width="150"
+                  height="50"
+                  style="display:block;width:150px;height:50px;max-width:150px;border:0;outline:none;text-decoration:none;"
+                />`;
 
 const paragraph = (content) =>
   `<p style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:#343330;">${content}</p>`;
@@ -257,7 +253,6 @@ const indexHtml = `<!doctype html>
 </html>`;
 
 await mkdir(outDir, { recursive: true });
-await copyFile(logoSource, path.join(outDir, logoFileName));
 await Promise.all(previews.map((preview) => writeFile(path.join(outDir, preview.file), preview.html)));
 await writeFile(path.join(outDir, "index.html"), indexHtml);
 

--- a/supabase/functions/_shared/emailBranding.ts
+++ b/supabase/functions/_shared/emailBranding.ts
@@ -6,31 +6,27 @@ const escapeHtmlAttribute = (value: string) =>
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
 
-const CANONICAL_EMAIL_LOGO_URL = "https://itemtraxx.com/brand/logo-light.png";
-const CANONICAL_EMAIL_LOGO_PATHS = new Set([
-  "/brand/logo-light.png",
-  "/brand/logo-dark.png",
-  "/brand/logo-mark.png",
-]);
+const CANONICAL_EMAIL_LOGO_URL = "https://assets.itemtraxx.com/brand/logo-light.png";
 
-const resolveSafeEmailLogoUrl = (candidate: string | null | undefined) => {
-  if (!candidate) return escapeHtmlAttribute(CANONICAL_EMAIL_LOGO_URL);
-  const trimmed = candidate.trim();
-  if (!trimmed) return escapeHtmlAttribute(CANONICAL_EMAIL_LOGO_URL);
+const normalizeEmailLogoUrl = (logoUrl?: string | null) => {
+  const candidate = logoUrl?.trim() || CANONICAL_EMAIL_LOGO_URL;
 
   try {
-    const url = new URL(trimmed);
-    if (url.protocol !== "https:") return escapeHtmlAttribute(CANONICAL_EMAIL_LOGO_URL);
-    if (
-      (url.hostname === "itemtraxx.com" || url.hostname === "www.itemtraxx.com") &&
-      CANONICAL_EMAIL_LOGO_PATHS.has(url.pathname)
-    ) {
-      return escapeHtmlAttribute(url.toString());
+    const parsed = new URL(candidate);
+    const isAllowedHost = parsed.hostname === "assets.itemtraxx.com";
+    const isAllowedLogo =
+      parsed.pathname === "/brand/logo-light.png" ||
+      parsed.pathname === "/brand/logo-dark.png" ||
+      parsed.pathname === "/brand/logo-mark.png";
+
+    if (parsed.protocol === "https:" && isAllowedHost && isAllowedLogo) {
+      return parsed.toString();
     }
-    return escapeHtmlAttribute(CANONICAL_EMAIL_LOGO_URL);
   } catch {
-    return escapeHtmlAttribute(CANONICAL_EMAIL_LOGO_URL);
+    return CANONICAL_EMAIL_LOGO_URL;
   }
+
+  return CANONICAL_EMAIL_LOGO_URL;
 };
 
 export const buildEmailBrandHeaderHtml = (params: {
@@ -38,15 +34,13 @@ export const buildEmailBrandHeaderHtml = (params: {
   brandName?: string;
 }) => {
   const brandName = params.brandName?.trim() || "ItemTraxx";
-  const safeLogoUrl = resolveSafeEmailLogoUrl(params.logoUrl);
+  const logoUrl = normalizeEmailLogoUrl(params.logoUrl);
 
-  return [
-    `<img`,
-    ` src="${safeLogoUrl}"`,
-    ` alt="${escapeHtmlAttribute(brandName)}"`,
-    ` width="150"`,
-    ` height="50"`,
-    ` style="display:block;width:150px;height:50px;max-width:150px;border:0;outline:none;text-decoration:none;"`,
-    ` />`,
-  ].join("");
+  return `<img
+                  src="${escapeHtmlAttribute(logoUrl)}"
+                  alt="${escapeHtmlAttribute(brandName)}"
+                  width="150"
+                  height="50"
+                  style="display:block;width:150px;height:50px;max-width:150px;border:0;outline:none;text-decoration:none;"
+                />`;
 };


### PR DESCRIPTION
This pull request updates how the brand logo is referenced and validated in email previews and shared email branding code. The main change is to standardize on using the logo hosted at `assets.itemtraxx.com` and to simplify the logic for validating and rendering the logo URL in emails.

**Brand logo URL standardization and validation:**

* Changed the canonical email logo URL to `https://assets.itemtraxx.com/brand/logo-light.png` in both `scripts/generate-email-previews.mjs` and `supabase/functions/_shared/emailBranding.ts`. [[1]](diffhunk://#diff-0f392e4aa1ada8bb17026dccd56a2000317402536460ecbf6cef8f7256f97af5L1-R11) [[2]](diffhunk://#diff-a8ba96dddbefdc72cb0239ab09457fc872fd9445bc1ecb85d02438ef40b1c91dL9-R45)
* Updated the logo URL validation logic in `normalizeEmailLogoUrl` to only allow logos from `assets.itemtraxx.com` with specific paths, removing legacy support for `itemtraxx.com` and simplifying the function.

**Email preview generation and rendering:**

* Updated the email preview generator (`generate-email-previews.mjs`) to reference the remote logo URL instead of copying a local file, and removed the file copy operation. [[1]](diffhunk://#diff-0f392e4aa1ada8bb17026dccd56a2000317402536460ecbf6cef8f7256f97af5L1-R11) [[2]](diffhunk://#diff-0f392e4aa1ada8bb17026dccd56a2000317402536460ecbf6cef8f7256f97af5L24-R28) [[3]](diffhunk://#diff-0f392e4aa1ada8bb17026dccd56a2000317402536460ecbf6cef8f7256f97af5L260)
* Refactored the email brand header HTML rendering to use the new logo URL and simplified the HTML template formatting for consistency. [[1]](diffhunk://#diff-0f392e4aa1ada8bb17026dccd56a2000317402536460ecbf6cef8f7256f97af5L24-R28) [[2]](diffhunk://#diff-a8ba96dddbefdc72cb0239ab09457fc872fd9445bc1ecb85d02438ef40b1c91dL9-R45)

Summary generated by Copilot.