### PR TITLE
update posthog-js to version 1.372.6 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "jsbarcode": "^3.12.3",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
-        "posthog-js": "^1.372.1",
+        "posthog-js": "^1.372.6",
         "supabase": "2.95.3",
         "vue": "^3.5.33",
         "vue-router": "^4.6.4",
@@ -1591,12 +1591,12 @@
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
-      "version": "1.27.6",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.6.tgz",
-      "integrity": "sha512-FjvgPdORywAjgjtgkZJ2/x9ED52jtOJym/RVldY4Oa7wzmlY49rxZm8gvOlocEnjP90bSbj3ko7qVjXNhftFvA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.0.tgz",
+      "integrity": "sha512-753giUMWuk602UtS101tDZuNcwiKkr+3UEhLgfOwHAk2W32n53knOxAjyWT0JwMq5/+0uSQ2y4uaZXQAxwvBSw==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.372.2"
+        "@posthog/types": "1.372.6"
       }
     },
     "node_modules/@posthog/react": {
@@ -1616,9 +1616,9 @@
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.372.2",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.2.tgz",
-      "integrity": "sha512-dx+WImdDg2NDqaDowTmW+BMNalUfPKngR+g1Iom8ULSav+fGacxexv6fSOl0uSVBwYZsDFe7qNUu0NB/rwGjEw==",
+      "version": "1.372.6",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.6.tgz",
+      "integrity": "sha512-sqI36LBvuo8xcYsXIlVa0q3IXJJjqtatM2LrXlyOM7kgHrldBwS4ldzaTXrTdpe/TiIl1b4ZHxtSHMzPig+DnQ==",
       "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3842,9 +3842,9 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.372.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.2.tgz",
-      "integrity": "sha512-FS+vKDXB1vghrVch3EDi3IRcoH5OnLQYxchHWi+8U4D4PzWQZnZLo5vyMRL1+ZUHNEZ2v599uX3UKhRZv2z6Cg==",
+      "version": "1.372.6",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.6.tgz",
+      "integrity": "sha512-+Fy9fwWni5WDKQXiUBIzFvdmnZSR6OBxGC/4wj09JvvK5JE4dhI9ZlKO1+b887PowjeAx0sx1Tf+S1eAjDvzqg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -3852,8 +3852,8 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.27.6",
-        "@posthog/types": "1.372.2",
+        "@posthog/core": "1.28.0",
+        "@posthog/types": "1.372.6",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jsbarcode": "^3.12.3",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
-    "posthog-js": "^1.372.1",
+    "posthog-js": "^1.372.6",
     "supabase": "2.95.3",
     "vue": "^3.5.33",
     "vue-router": "^4.6.4",


### PR DESCRIPTION
This pull request updates the version of the `posthog-js` dependency in the `package.json` file. The update moves from version 1.372.1 to 1.372.6, ensuring the project uses the latest minor and patch fixes for this analytics library. No other changes are included.

- Dependency update:
  * Upgraded `posthog-js` from version 1.372.1 to 1.372.6 in `package.json` to include recent fixes and improvements.

This pull request addresses an issue with session replays not appearing in the posthog dashboard. 

Summary generated by Copilot.