### PR TITLE
docs: update public changelog through 2026-05-07 and adjust schedule watchdog timing

### DIFF
--- a/.github/workflows/schedule-watchdog.yml
+++ b/.github/workflows/schedule-watchdog.yml
@@ -31,13 +31,22 @@ jobs:
           check_workflow() {
             local workflow_file="$1"
             local workflow_name="$2"
-            local max_age_seconds="$3"
+            local heartbeat_max_age_seconds="$3"
+            local success_max_age_seconds="$4"
 
             local response
             response="$(curl -fsSL \
               -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
-              "${API_BASE}/actions/workflows/${workflow_file}/runs?event=schedule&branch=main&status=completed&per_page=20")"
+              "${API_BASE}/actions/workflows/${workflow_file}/runs?event=schedule&branch=main&status=completed&per_page=50")"
+
+            local latest_completed
+            latest_completed="$(printf '%s' "$response" | jq -r '
+              .workflow_runs
+              | sort_by(.created_at)
+              | reverse
+              | .[0].created_at // empty
+            ')"
 
             local latest_success
             latest_success="$(printf '%s' "$response" | jq -r '
@@ -48,24 +57,41 @@ jobs:
               | .[0].created_at // empty
             ')"
 
-            if [ -z "$latest_success" ]; then
-              STALE_REPORT="${STALE_REPORT}\n- ${workflow_name}: no successful scheduled runs found"
+            if [ -z "$latest_completed" ]; then
+              STALE_REPORT="${STALE_REPORT}\n- ${workflow_name}: no completed scheduled runs found"
               return
             fi
 
-            local latest_epoch age_minutes max_age_minutes
-            latest_epoch="$(python3 -c 'from datetime import datetime; import sys; print(int(datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00")).timestamp()))' "$latest_success")"
-            age_minutes="$(( (CURRENT_EPOCH - latest_epoch) / 60 ))"
-            max_age_minutes="$(( max_age_seconds / 60 ))"
+            local latest_completed_epoch completed_age_minutes heartbeat_max_age_minutes
+            latest_completed_epoch="$(python3 -c 'from datetime import datetime; import sys; print(int(datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00")).timestamp()))' "$latest_completed")"
+            completed_age_minutes="$(( (CURRENT_EPOCH - latest_completed_epoch) / 60 ))"
+            heartbeat_max_age_minutes="$(( heartbeat_max_age_seconds / 60 ))"
 
-            if [ $(( CURRENT_EPOCH - latest_epoch )) -gt "$max_age_seconds" ]; then
-              STALE_REPORT="${STALE_REPORT}\n- ${workflow_name}: last successful scheduled run was ${age_minutes} minutes ago (threshold ${max_age_minutes} minutes)"
+            if [ $(( CURRENT_EPOCH - latest_completed_epoch )) -gt "$heartbeat_max_age_seconds" ]; then
+              STALE_REPORT="${STALE_REPORT}\n- ${workflow_name}: last completed scheduled run was ${completed_age_minutes} minutes ago (heartbeat threshold ${heartbeat_max_age_minutes} minutes)"
+              return
+            fi
+
+            if [ -z "$latest_success" ]; then
+              STALE_REPORT="${STALE_REPORT}\n- ${workflow_name}: no successful scheduled runs in recent history"
+              return
+            fi
+
+            local latest_success_epoch success_age_minutes success_max_age_minutes
+            latest_success_epoch="$(python3 -c 'from datetime import datetime; import sys; print(int(datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00")).timestamp()))' "$latest_success")"
+            success_age_minutes="$(( (CURRENT_EPOCH - latest_success_epoch) / 60 ))"
+            success_max_age_minutes="$(( success_max_age_seconds / 60 ))"
+
+            if [ $(( CURRENT_EPOCH - latest_success_epoch )) -gt "$success_max_age_seconds" ]; then
+              STALE_REPORT="${STALE_REPORT}\n- ${workflow_name}: last successful scheduled run was ${success_age_minutes} minutes ago (success threshold ${success_max_age_minutes} minutes)"
             fi
           }
 
-          check_workflow "async-job-worker.yml" "Async Job Worker" 7200
-          check_workflow "synthetic-journeys.yml" "Synthetic Journeys" 10800
-          check_workflow "deployment-health.yml" "Deployment Health" 14400
+          # heartbeat threshold catches true schedule outages quickly
+          # success threshold stays looser to avoid noise from transient failures
+          check_workflow "async-job-worker.yml" "Async Job Worker" 1800 7200
+          check_workflow "synthetic-journeys.yml" "Synthetic Journeys" 5400 10800
+          check_workflow "deployment-health.yml" "Deployment Health" 10800 14400
           if [ -n "$STALE_REPORT" ]; then
             {
               echo "stale=true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated (year-month-day): 2026-05-07
+Last updated (year-month-day): 2026-05-08
 
 This public changelog summarizes notable ItemTraxx product, reliability, security, and experience updates at a high level. Detailed internal engineering and operational notes are maintained separately.
 
@@ -15,6 +15,13 @@ Changes are dated based on the default timezone: America/Los_Angeles
 - [TERMS.md](TERMS.md) – Terms of service for users
 - [PRIVACY.md](PRIVACY.md) – Privacy policy and data handling
 - [SECURITY.md](SECURITY.md) – Security reporting and guidelines
+
+---
+
+### 5/08/2026 Development Update
+
+- Completed maintenance and reliability follow-up tasks with no new user-facing product or UI changes.
+- Continued operational verification of security and deployment workflows.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated (year-month-day): 2026-05-06
+Last updated (year-month-day): 2026-05-07
 
 This public changelog summarizes notable ItemTraxx product, reliability, security, and experience updates at a high level. Detailed internal engineering and operational notes are maintained separately.
 
@@ -15,6 +15,15 @@ Changes are dated based on the default timezone: America/Los_Angeles
 - [TERMS.md](TERMS.md) – Terms of service for users
 - [PRIVACY.md](PRIVACY.md) – Privacy policy and data handling
 - [SECURITY.md](SECURITY.md) – Security reporting and guidelines
+
+---
+
+### 5/07/2026 Development Update
+
+- Improved tenant-admin reliability and usability across admin management flows.
+- Refined notification behavior so attention badges dismiss after review and reappear only for new updates.
+- Tightened checkout safety rules so only eligible items can be processed in checkout/return flows.
+- Continued security hardening and edge-function configuration cleanup tied to vulnerability findings.
 
 ---
 


### PR DESCRIPTION
This pull request updates the scheduled workflow watchdog script to improve reliability monitoring and reporting, and also updates the changelog with the latest development notes. The main changes are focused on making the workflow schedule checks more robust by distinguishing between "heartbeat" (any recent run) and "success" (recent successful run) thresholds, and providing clearer reporting for workflow staleness.

**Workflow Watchdog Improvements:**

- Refactored the `check_workflow` function in `.github/workflows/schedule-watchdog.yml` to use separate "heartbeat" and "success" thresholds for detecting stale workflows, allowing for quicker detection of schedule outages while reducing noise from transient failures. [[1]](diffhunk://#diff-c8cadc393f9f9658b497b0d964d715eb840a938996b4ceb42ae282c02fb74f90L34-R49) [[2]](diffhunk://#diff-c8cadc393f9f9658b497b0d964d715eb840a938996b4ceb42ae282c02fb74f90R60-R94)
- Improved reporting: Now distinguishes between missing completed runs and missing successful runs, and provides more informative messages about the last run's age relative to the configured thresholds.
- Increased the number of workflow runs fetched per check from 20 to 50 to ensure more comprehensive history is considered.
- Updated the threshold values for each monitored workflow to use the new heartbeat/success distinction, with comments explaining the rationale.

**Documentation Updates:**

- Updated `CHANGELOG.md` with entries for 5/07/2026 and 5/08/2026, summarizing recent development, maintenance, and reliability work. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R36)

Summary generated by Copilot.