### PR TITLE
feat: add Cross-Origin headers for brand resources in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,19 @@
 {
   "headers": [
     {
+      "source": "/brand/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "cross-origin"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         {


### PR DESCRIPTION
This pull request adds new HTTP headers for requests to the `/brand/` path in the `vercel.json` configuration. These headers are intended to enable cross-origin resource sharing for assets served from this path.

**CORS and resource policy enhancements:**

* Added `Cross-Origin-Resource-Policy: cross-origin` and `Access-Control-Allow-Origin: *` headers for all requests to the `/brand/` path to allow cross-origin access to these resources.

Summary generated by Copilot.