### PR TITLE
feat: reorder Cross-Origin headers for brand resources in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,19 +1,6 @@
 {
   "headers": [
     {
-      "source": "/brand/(.*)",
-      "headers": [
-        {
-          "key": "Cross-Origin-Resource-Policy",
-          "value": "cross-origin"
-        },
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "*"
-        }
-      ]
-    },
-    {
       "source": "/assets/(.*)",
       "headers": [
         {
@@ -65,6 +52,19 @@
         {
           "key": "Cross-Origin-Resource-Policy",
           "value": "same-site"
+        }
+      ]
+    },
+    {
+      "source": "/brand/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "cross-origin"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
         }
       ]
     }


### PR DESCRIPTION
This pull request updates the `vercel.json` configuration to reorder the custom HTTP headers for specific routes. The main change is moving the `/brand/(.*)` route headers after the `/assets/(.*)` route headers.

Routing and header configuration:

* Moved the custom headers for the `/brand/(.*)` route (including `Cross-Origin-Resource-Policy: cross-origin` and `Access-Control-Allow-Origin: *`) to appear after the `/assets/(.*)` route headers in the `vercel.json` file. [[1]](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240L3-L15) [[2]](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R57-R69)

Summary generated by Copilot.