### PR TITLE
feat: remove Cross-Origin-Resource-Policy header from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,10 +48,6 @@
         {
           "key": "Cross-Origin-Opener-Policy",
           "value": "same-origin"
-        },
-        {
-          "key": "Cross-Origin-Resource-Policy",
-          "value": "same-site"
         }
       ]
     },


### PR DESCRIPTION
This pull request makes a small change to the `vercel.json` configuration file by removing the `Cross-Origin-Resource-Policy` header. This simplifies the response headers sent by the server.

Summary generated by Copilot.