### PR TITLE
feat: update source pattern for headers to exclude brand resources in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "source": "/(.*)",
+      "source": "/((?!brand/).*)",
       "headers": [
         {
           "key": "Content-Security-Policy",


### PR DESCRIPTION
This pull request makes a targeted update to the `vercel.json` routing configuration. The main change is to exclude all routes starting with `brand/` from a specific rewrite rule, which likely helps to apply different handling or headers for those routes.

- Routing configuration update:
  * Modified the route source pattern to exclude paths beginning with `brand/`, ensuring that the rule does not apply to those routes. (`vercel.json`)

Summary generated by Copilot.