### PR TITLE
feat: implement maintenance mode fallback for system status and caching

### DIFF
--- a/cloudflare/edge-proxy/src/index.ts
+++ b/cloudflare/edge-proxy/src/index.ts
@@ -1,3 +1,9 @@
+type KvBinding = {
+  get: <T = string>(key: string, type?: "text" | "json") => Promise<T | null>;
+  put: (key: string, value: string, options?: { expirationTtl?: number }) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+};
+
 export interface Env {
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
@@ -13,6 +19,7 @@ export interface Env {
   SESSION_REFRESH_COOKIE_MAX_AGE_SECONDS?: string;
   SENTRY_DSN?: string;
   SENTRY_ENVIRONMENT?: string;
+  MAINTENANCE_FALLBACK_KV?: KvBinding;
 }
 
 const ACCESS_COOKIE_NAME = "itx_session";
@@ -28,6 +35,7 @@ const EDGE_PROXY_TIMESTAMP_HEADER = "x-itx-edge-proxy-ts";
 const EDGE_PROXY_SIGNATURE_HEADER = "x-itx-edge-proxy-signature";
 const DEFAULT_KILL_SWITCH_MESSAGE =
   "Unfortunately ItemTraxx is currently unavailable. We apologize for any inconvenience and are working to restore access as soon as possible. Please see the status page (https://status.itemtraxx.com/) for more information.";
+const MAINTENANCE_FALLBACK_KEY = "itemtraxx:maintenance_fallback:v1";
 
 const BASE_CORS_HEADERS = {
   "Access-Control-Allow-Headers":
@@ -133,9 +141,102 @@ type ProfileRow = {
   is_active: boolean | null;
 };
 
+type MaintenanceFallbackPayload = {
+  enabled: boolean;
+  message: string;
+  updated_at: string;
+};
+
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 const resolveKillSwitchMessage = (env: Env) =>
   env.ITX_ITEMTRAXX_KILLSWITCH_MESSAGE?.trim() || DEFAULT_KILL_SWITCH_MESSAGE;
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+
+const readMaintenanceFallback = async (env: Env): Promise<MaintenanceFallbackPayload | null> => {
+  if (!env.MAINTENANCE_FALLBACK_KV) return null;
+  try {
+    const cached = await env.MAINTENANCE_FALLBACK_KV.get(MAINTENANCE_FALLBACK_KEY, "json");
+    const record = asRecord(cached);
+    if (!record) return null;
+    if (record.enabled !== true) return null;
+    if (typeof record.message !== "string" || typeof record.updated_at !== "string") return null;
+    return {
+      enabled: true,
+      message: record.message.trim() || "Maintenance currently in progress.",
+      updated_at: record.updated_at,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const writeMaintenanceFallback = async (
+  env: Env,
+  payload: MaintenanceFallbackPayload | null
+) => {
+  if (!env.MAINTENANCE_FALLBACK_KV) return;
+  try {
+    if (!payload) {
+      await env.MAINTENANCE_FALLBACK_KV.delete(MAINTENANCE_FALLBACK_KEY);
+      return;
+    }
+    await env.MAINTENANCE_FALLBACK_KV.put(MAINTENANCE_FALLBACK_KEY, JSON.stringify(payload), {
+      expirationTtl: 60 * 60 * 24 * 14,
+    });
+  } catch {
+    // best effort only
+  }
+};
+
+const extractMaintenanceFromStatusPayload = (
+  payload: Record<string, unknown>
+): MaintenanceFallbackPayload | null => {
+  const maintenance = asRecord(payload.maintenance);
+  if (!maintenance) return null;
+  if (maintenance.enabled !== true) return { enabled: false, message: "", updated_at: new Date().toISOString() };
+  return {
+    enabled: true,
+    message:
+      typeof maintenance.message === "string" && maintenance.message.trim()
+        ? maintenance.message.trim()
+        : "Maintenance currently in progress.",
+    updated_at:
+      typeof maintenance.updated_at === "string" && maintenance.updated_at.trim()
+        ? maintenance.updated_at
+        : new Date().toISOString(),
+  };
+};
+
+const applyMaintenanceFallbackToStatusPayload = async (
+  env: Env,
+  upstreamStatusCode: number,
+  payload: Record<string, unknown>
+) => {
+  const extracted = extractMaintenanceFromStatusPayload(payload);
+  if (extracted?.enabled === true) {
+    await writeMaintenanceFallback(env, extracted);
+    return payload;
+  }
+  if (extracted?.enabled === false) {
+    await writeMaintenanceFallback(env, null);
+  }
+
+  const status = typeof payload.status === "string" ? payload.status : "";
+  const checks = asRecord(payload.checks);
+  const dbFailed = checks?.db === "failed";
+  const shouldFallback = upstreamStatusCode >= 500 || status === "down" || dbFailed;
+  if (!shouldFallback) return payload;
+
+  const cached = await readMaintenanceFallback(env);
+  if (!cached) return payload;
+  return {
+    ...payload,
+    maintenance: cached,
+    maintenance_fallback: true,
+  };
+};
 
 const parseSentryDsn = (dsn?: string | null) => {
   if (!dsn) return null;
@@ -834,6 +935,7 @@ const proxyFunctionRequest = async (
 ) => {
   const cookies = parseCookies(request);
   const supabaseFunctionUrl = `${trimTrailingSlash(env.SUPABASE_URL)}/functions/v1/${functionName}`;
+  const isSystemStatusGet = functionName === "system-status" && request.method === "GET";
   const invoke = async (sessionAccessToken?: string | null) => {
     const proxiedHeaders = sanitizeRequestHeaders(
       request,
@@ -856,7 +958,35 @@ const proxyFunctionRequest = async (
     return fetch(supabaseFunctionUrl, init);
   };
 
-  let upstreamResponse = await invoke(cookies.accessToken);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await invoke(cookies.accessToken);
+  } catch (error) {
+    if (isSystemStatusGet) {
+      const cached = await readMaintenanceFallback(env);
+      if (cached) {
+        const responseHeaders = new Headers();
+        Object.entries(headers).forEach(([key, value]) => responseHeaders.set(key, value));
+        responseHeaders.set("x-request-id", requestId);
+        responseHeaders.set("content-type", "application/json");
+        return new Response(
+          JSON.stringify({
+            status: "down",
+            checks: { config: "ok", db: "failed" },
+            maintenance: cached,
+            maintenance_fallback: true,
+            incident_summary: "system status unavailable; maintenance fallback active",
+            checked_at: new Date().toISOString(),
+          }),
+          {
+            status: 503,
+            headers: responseHeaders,
+          }
+        );
+      }
+    }
+    throw error;
+  }
   let sessionHeaders: Headers | null = null;
 
   if (!request.headers.get("Authorization") && upstreamResponse.status === 401 && cookies.refreshToken) {
@@ -872,6 +1002,25 @@ const proxyFunctionRequest = async (
   responseHeaders.set("x-request-id", requestId);
   if (sessionHeaders) {
     appendSetCookies(responseHeaders, sessionHeaders);
+  }
+
+  if (isSystemStatusGet) {
+    const rawBody = await upstreamResponse.clone().text();
+    try {
+      const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+      const withFallback = await applyMaintenanceFallbackToStatusPayload(
+        env,
+        upstreamResponse.status,
+        parsed
+      );
+      responseHeaders.set("content-type", "application/json");
+      return new Response(JSON.stringify(withFallback), {
+        status: upstreamResponse.status,
+        headers: responseHeaders,
+      });
+    } catch {
+      // preserve original upstream payload when JSON parsing fails
+    }
   }
 
   return new Response(upstreamResponse.body, {

--- a/cloudflare/edge-proxy/wrangler.toml
+++ b/cloudflare/edge-proxy/wrangler.toml
@@ -13,6 +13,12 @@ ALLOWED_FUNCTIONS = "tenant-login,checkoutReturn,create-tenant-admin,admin-gear-
 ITX_ITEMTRAXX_KILLSWITCH_ENABLED = "false"
 SENTRY_ENVIRONMENT = "production"
 
+# Optional: enables maintenance-mode fallback state when system-status
+# cannot read Supabase during outages/upgrades.
+[[kv_namespaces]]
+binding = "MAINTENANCE_FALLBACK_KV"
+id = "09542de7b51b4edcb189f38addcba602"
+
 [[routes]]
 pattern = "edge.itemtraxx.com"
 zone_name = "itemtraxx.com"

--- a/src/App.vue
+++ b/src/App.vue
@@ -368,6 +368,7 @@ const maintenanceEnabled = ref(false);
 const maintenanceMessage = ref("Maintenance currentlyin progress.");
 const killSwitchEnabled = ref(false);
 const killSwitchMessage = ref("Unfortunately ItemTraxx is currently unavailable. We apologize for any inconvenience and are working to restore access as soon as possible. Please see the status page (https://status.itemtraxx.com/) for more information.");
+const backendUnavailable = ref(false);
 const statusLabel = ref("Unknown");
 const statusClass = ref<"status-ok" | "status-warn" | "status-down" | "status-unknown">(
   "status-unknown"
@@ -418,6 +419,53 @@ const GITHUB_HEAD_COMMIT_API =
   "https://api.github.com/repos/ItemTraxxCo/ItemTraxx-App/commits/main";
 const appBranch = (import.meta.env.VITE_GIT_BRANCH || "n/a").trim();
 const isNonMainBuild = appBranch !== "" && appBranch !== "n/a" && appBranch !== "main";
+const MAINTENANCE_CACHE_KEY = "itemtraxx-maintenance-state";
+
+type CachedMaintenanceState = {
+  enabled: boolean;
+  message: string;
+  updatedAt: string;
+};
+
+const readCachedMaintenanceState = (): CachedMaintenanceState | null => {
+  try {
+    const raw = localStorage.getItem(MAINTENANCE_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CachedMaintenanceState>;
+    if (
+      typeof parsed.enabled !== "boolean" ||
+      typeof parsed.message !== "string" ||
+      typeof parsed.updatedAt !== "string"
+    ) {
+      return null;
+    }
+    return {
+      enabled: parsed.enabled,
+      message: parsed.message.trim() || "Maintenance currently in progress.",
+      updatedAt: parsed.updatedAt,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const writeCachedMaintenanceState = (state: CachedMaintenanceState | null) => {
+  try {
+    if (!state) {
+      localStorage.removeItem(MAINTENANCE_CACHE_KEY);
+      return;
+    }
+    localStorage.setItem(MAINTENANCE_CACHE_KEY, JSON.stringify(state));
+  } catch {
+    // Best effort only.
+  }
+};
+
+const cachedMaintenanceState = readCachedMaintenanceState();
+if (cachedMaintenanceState?.enabled) {
+  maintenanceEnabled.value = true;
+  maintenanceMessage.value = cachedMaintenanceState.message;
+}
 
 const showCookieConsentBanner = computed(() => !hasCookieConsent(cookieConsent.value));
 
@@ -606,7 +654,6 @@ const showMaintenanceOverlay = computed(() => {
   if (!maintenanceEnabled.value) return false;
   const routeName = String(route.name || "");
   if (
-    routeName === "public-home" ||
     routeName === "public-unavailable" ||
     routeName === "not-found" ||
     routeName === "super-auth" ||
@@ -1081,6 +1128,7 @@ const refreshSystemStatus = async () => {
   if (!response) {
     statusLabel.value = "Unknown";
     statusClass.value = "status-unknown";
+    backendUnavailable.value = false;
     return;
   }
 
@@ -1112,26 +1160,53 @@ const refreshSystemStatus = async () => {
     activeBroadcast.value = null;
   }
 
-  if (payload.maintenance?.enabled) {
-    maintenanceEnabled.value = true;
-    maintenanceMessage.value =
-      typeof payload.maintenance.message === "string" && payload.maintenance.message.trim()
+  const hasMaintenancePayload =
+    payload.maintenance && typeof payload.maintenance === "object";
+  if (hasMaintenancePayload) {
+    const enabled = payload.maintenance?.enabled === true;
+    const message =
+      typeof payload.maintenance?.message === "string" &&
+      payload.maintenance.message.trim()
         ? payload.maintenance.message.trim()
         : "Maintenance currently in progress.";
+    maintenanceEnabled.value = enabled;
+    maintenanceMessage.value = message;
+    if (enabled) {
+      writeCachedMaintenanceState({
+        enabled: true,
+        message,
+        updatedAt:
+          typeof payload.maintenance?.updated_at === "string"
+            ? payload.maintenance.updated_at
+            : new Date().toISOString(),
+      });
+    } else {
+      writeCachedMaintenanceState(null);
+    }
+  } else if (response.status >= 500 || payload.status === "down") {
+    // Keep last known maintenance state during backend outages.
+    const cached = readCachedMaintenanceState();
+    if (cached?.enabled) {
+      maintenanceEnabled.value = true;
+      maintenanceMessage.value = cached.message;
+    }
   } else {
     maintenanceEnabled.value = false;
+    writeCachedMaintenanceState(null);
   }
 
   if (response.ok && payload.status === "operational") {
     statusLabel.value = "Running";
     statusClass.value = "status-ok";
     incidentBanner.value = null;
+    backendUnavailable.value = false;
     return;
   }
 
   if (response.status >= 500 || payload.status === "down") {
     statusLabel.value = "Down";
     statusClass.value = "status-down";
+    backendUnavailable.value = !maintenanceEnabled.value;
     const incidentId =
       (payload.checked_at && String(payload.checked_at)) ||
       `${payload.status}-${payload.incident_summary || "down"}`;
@@ -1149,6 +1224,7 @@ const refreshSystemStatus = async () => {
 
   statusLabel.value = "Degraded";
   statusClass.value = "status-warn";
+  backendUnavailable.value = false;
   const incidentId =
     (payload.checked_at && String(payload.checked_at)) ||
     `${payload.status}-${payload.incident_summary || "degraded"}`;
@@ -1339,6 +1415,16 @@ watch(
   ([enabled, path]) => {
     if (!enabled || isLocalDevMaintenanceBypass.value) return;
     if (path !== "/" && path !== "/unavailable") {
+      void router.replace("/unavailable");
+    }
+  }
+);
+
+watch(
+  () => [backendUnavailable.value, route.path] as const,
+  ([isUnavailable, path]) => {
+    if (!isUnavailable || isLocalDevMaintenanceBypass.value) return;
+    if (path !== "/unavailable") {
       void router.replace("/unavailable");
     }
   }


### PR DESCRIPTION

This pull request introduces a robust maintenance-mode fallback system to ensure users receive appropriate messaging and degraded service status when backend outages or upgrades prevent reading the system status from Supabase. The changes span both the Cloudflare edge proxy and the frontend app, adding a KV-based fallback cache and frontend persistence to maintain maintenance state visibility even during outages.

**Edge Proxy: Maintenance Fallback System**

* Added a KV binding (`MAINTENANCE_FALLBACK_KV`) to persist maintenance state and implemented logic to read, write, and apply this fallback when the system-status endpoint is unavailable or returns errors. This ensures that a maintenance message can still be shown to users during backend outages. [[1]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR1-R6) [[2]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR22) [[3]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR38) [[4]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR144-R240) [[5]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR938) [[6]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bL859-R989) [[7]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR1007-R1025) [[8]](diffhunk://#diff-35271902889d9cb51873d1f429038399c53fb96c398a462336e3f94bfecc810eR16-R21)

**Frontend App: Maintenance State Persistence and Fallback**

* Introduced logic to cache and read maintenance state in `localStorage`, allowing the frontend to persist and display maintenance messages even if the backend is unreachable. The UI now displays the last known maintenance state during outages. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R422-R468) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L1115-R1209)
* Updated the `refreshSystemStatus` function and related UI state to use the cached maintenance state as a fallback, improving user experience during backend errors or downtime. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R1131) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L1115-R1209) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R1227)
* Added a `backendUnavailable` state and a watcher to automatically redirect users to the `/unavailable` route when the backend is down and maintenance mode is not enabled. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R371) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R1423-R1432)

**Other Frontend Improvements**

* Minor UI logic adjustments to ensure maintenance overlays and banners are shown appropriately based on the new fallback and cached state.

These changes collectively ensure that users are kept informed about maintenance periods even if the backend is unreachable, and that the maintenance message is consistent and persistent across outages.

Summary generated by Copilot.