### PR TITLE
fix: update links to point to unavailable page and improve layout for maintenance mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,7 +41,7 @@
       aria-live="assertive"
       aria-modal="true"
     >
-      <a class="kill-switch-logo-link" href="/" aria-label="ItemTraxx home">
+      <a class="kill-switch-logo-link" href="/unavailable" aria-label="ItemTraxx unavailable">
         <img
           v-if="brandLogoUrl"
           class="kill-switch-logo"
@@ -868,7 +868,7 @@ const maybeRedirectAuthenticatedPublicHome = async () => {
 };
 
 const reloadApp = () => {
-  window.location.reload();
+  window.location.assign(`${window.location.origin}/`);
 };
 
 const signInAgain = async () => {

--- a/src/pages/Unavailable.vue
+++ b/src/pages/Unavailable.vue
@@ -4,7 +4,7 @@
     :class="{ 'unavailable-page-dark': themeMode === 'dark' }"
     aria-labelledby="unavailable-title"
   >
-    <a class="unavailable-logo-link" href="/" aria-label="ItemTraxx home">
+    <a class="unavailable-logo-link" href="/unavailable" aria-label="ItemTraxx unavailable">
       <img v-if="brandLogoUrl" class="unavailable-logo" :src="brandLogoUrl" alt="ItemTraxx Co" />
     </a>
     <button
@@ -55,7 +55,7 @@ const brandLogoUrl = computed(() =>
 let themeObserver: MutationObserver | null = null;
 
 const refreshPage = () => {
-  window.location.reload();
+  window.location.assign(`${window.location.origin}/`);
 };
 
 const applyTheme = (next: "light" | "dark") => {

--- a/src/style.css
+++ b/src/style.css
@@ -987,13 +987,22 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  align-items: stretch;
   gap: 0.75rem;
+  width: 100%;
+}
+
+.maintenance-fullscreen-actions > * {
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .maintenance-fullscreen .button-link {
   background: #151515;
   border-color: #2f2f2c;
   color: #f3f3f0;
+  white-space: normal;
+  text-align: center;
 }
 
 .maintenance-fullscreen .button-link:hover:not(:disabled) {
@@ -1003,6 +1012,7 @@ textarea {
 
 .maintenance-fullscreen .button-primary {
   min-width: 7.5rem;
+  max-width: 100%;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
This pull request updates the unavailable/maintenance page experience and improves related styling and navigation. The main changes include updating logo links to point to the correct unavailable page, changing page reload behavior to a full location redirect, and refining the layout and responsiveness of maintenance page actions.

**Unavailable/Maintenance Page Navigation:**
* Updated logo links in both `App.vue` and `Unavailable.vue` to point to `/unavailable` instead of the home page, clarifying the navigation flow when the site is unavailable. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L44-R44) [[2]](diffhunk://#diff-ec93f28128ba6220d5bf8ddb938f73635c27cbcccd6847112a90bad5eee08797L7-R7)

**Reload and Refresh Behavior:**
* Changed the refresh/reload functions in both `App.vue` and `Unavailable.vue` to use `window.location.assign` to `/` instead of `window.location.reload()`, ensuring a full redirect to the root and consistent behavior. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L871-R871) [[2]](diffhunk://#diff-ec93f28128ba6220d5bf8ddb938f73635c27cbcccd6847112a90bad5eee08797L58-R58)

**Styling and Layout Improvements:**
* Enhanced the `.maintenance-fullscreen-actions` layout and button styles in `style.css` for better alignment, wrapping, and responsiveness, especially on smaller screens. [[1]](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R990-R1005) [[2]](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R1015)


Summary generated by Copilot.