### PR TITLE
bugfixes and testing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated (year-month-day): 2026-05-08
+Last updated (year-month-day): 2026-05-10
 
 This public changelog summarizes notable ItemTraxx product, reliability, security, and experience updates at a high level. Detailed internal engineering and operational notes are maintained separately.
 
@@ -15,6 +15,14 @@ Changes are dated based on the default timezone: America/Los_Angeles
 - [TERMS.md](TERMS.md) – Terms of service for users
 - [PRIVACY.md](PRIVACY.md) – Privacy policy and data handling
 - [SECURITY.md](SECURITY.md) – Security reporting and guidelines
+
+---
+
+### 5/10/2026 Development Update
+
+- Improved checkout/return reliability and borrower-ownership safeguards for tenant checkout workflows.
+- Added and stabilized end-to-end regression coverage for borrower-specific checkout/return behavior.
+- Hardened CI E2E environment parity and reduced test flake risk in Playwright checks.
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,7 @@ const e2eSupabaseUrl =
 const e2eSupabaseAnonKey =
   process.env.VITE_SUPABASE_ANON_KEY ||
   "sb_publishable_dummy_for_e2e_tests_only";
+const e2eEdgeProxyUrl = process.env.VITE_EDGE_PROXY_URL || baseURL;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -29,6 +30,7 @@ export default defineConfig({
       VITE_E2E_TEST_UTILS: "true",
       VITE_SUPABASE_URL: e2eSupabaseUrl,
       VITE_SUPABASE_ANON_KEY: e2eSupabaseAnonKey,
+      VITE_EDGE_PROXY_URL: e2eEdgeProxyUrl,
     },
     url: baseURL,
     timeout: 120_000,

--- a/src/pages/tenant/Checkout.vue
+++ b/src/pages/tenant/Checkout.vue
@@ -344,19 +344,25 @@ const addBarcode = async () => {
   try {
     const gear = await fetchGearByBarcode(value);
     const normalizedStatus = String(gear.status ?? "").toLowerCase();
-    if (normalizedStatus !== "available") {
-      throw new Error(
-        "Only items with status “available” can be added to checkout/return."
-      );
-    }
     const isCurrentBorrowerReturn = checkedOutGear.value.some(
       (item) => item.barcode === gear.barcode
     );
-    if (gear.status === "checked_out" && !isCurrentBorrowerReturn) {
+    if (normalizedStatus === "available") {
+      barcodes.value = [...barcodes.value, gear];
+      barcodeInput.value = "";
+      return;
+    }
+    if (normalizedStatus === "checked_out" && isCurrentBorrowerReturn) {
+      barcodes.value = [...barcodes.value, gear];
+      barcodeInput.value = "";
+      return;
+    }
+    if (normalizedStatus === "checked_out" && !isCurrentBorrowerReturn) {
       throw new Error("Item already checked out.");
     }
-    barcodes.value = [...barcodes.value, gear];
-    barcodeInput.value = "";
+    throw new Error(
+      "Only items with status “available” can be added to checkout/return."
+    );
   } catch (err) {
     const message = toUserFacingErrorMessage(err, "Invalid barcode. Please check it and try again.");
     error.value = message;

--- a/src/pages/tenant/Checkout.vue
+++ b/src/pages/tenant/Checkout.vue
@@ -274,6 +274,13 @@ const syncOfflineBuffer = async (showWhenNoOps = false) => {
   }
 };
 
+const waitForPendingSync = async () => {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (!syncInFlight.value) return;
+    await new Promise((resolve) => window.setTimeout(resolve, 50));
+  }
+};
+
 const downloadReceiptPdf = async () => {
   if (!receipt.value) return;
   const [{ downloadTransactionReceiptPdf }] = await Promise.all([
@@ -430,6 +437,14 @@ const submit = async () => {
         toastTitle.value = "Transaction failed.";
         toastMessage.value = error.value || "Unable to load borrower. Please sign out completeley and sign back in. If issue persists, contact support.";
         return;
+      }
+    }
+
+    if (navigator.onLine) {
+      await waitForPendingSync();
+      await syncOfflineBuffer(false);
+      if (student.value) {
+        checkedOutGear.value = await fetchCheckedOutGear(student.value.id);
       }
     }
 

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -21,6 +21,8 @@ type CheckoutReturnResponse = {
   success: boolean;
   processed: number;
   skipped_barcodes?: string[];
+  error?: string;
+  message?: string;
 };
 
 type BufferedCheckoutItem = {
@@ -102,6 +104,10 @@ const executeCheckoutReturn = async (payload: CheckoutReturnPayload) => {
         ? `Item ${skippedBarcodes[0]} is already checked out or no longer available.`
         : `${skippedBarcodes.length} item(s) are already checked out or no longer available.`;
     throw new Error(`${label} Refresh and try again.`);
+  }
+
+  if (result.data && result.data.success === false) {
+    throw new Error(result.data.error || result.data.message || "Request failed.");
   }
 
   return result.data;

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -120,8 +120,8 @@ export const submitCheckoutReturn = async (
         try {
           await executeCheckoutReturn(payload);
           return { buffered: false, queuedCount: readOfflineQueue().length };
-        } catch {
-          throw new Error("Unable to reach ItemTraxx servers right now. Please try again.");
+        } catch (retryError) {
+          throw retryError;
         }
       }
       const queuedCount = queueCheckoutPayload(payload, message);

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -116,13 +116,15 @@ export const submitCheckoutReturn = async (
   } catch (error) {
     const message = error instanceof Error ? error.message : "Request failed.";
     if (isRetryableNetworkFailure(0, message)) {
-      const queuedCount = queueCheckoutPayload(payload, message);
       if (navigator.onLine) {
-        const syncResult = await syncBufferedCheckoutQueue();
-        if (syncResult.processed > 0 && syncResult.remaining === 0) {
-          return { buffered: false, queuedCount: 0 };
+        try {
+          await executeCheckoutReturn(payload);
+          return { buffered: false, queuedCount: readOfflineQueue().length };
+        } catch {
+          throw new Error("Unable to reach ItemTraxx servers right now. Please try again.");
         }
       }
+      const queuedCount = queueCheckoutPayload(payload, message);
       return { buffered: true, queuedCount };
     }
     throw error;

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -117,6 +117,12 @@ export const submitCheckoutReturn = async (
     const message = error instanceof Error ? error.message : "Request failed.";
     if (isRetryableNetworkFailure(0, message)) {
       const queuedCount = queueCheckoutPayload(payload, message);
+      if (navigator.onLine) {
+        const syncResult = await syncBufferedCheckoutQueue();
+        if (syncResult.processed > 0 && syncResult.remaining === 0) {
+          return { buffered: false, queuedCount: 0 };
+        }
+      }
       return { buffered: true, queuedCount };
     }
     throw error;

--- a/supabase/functions/checkoutReturn/index.ts
+++ b/supabase/functions/checkoutReturn/index.ts
@@ -264,13 +264,12 @@ serve(async (req) => {
         continue;
       }
 
-      if (String(gear.status ?? "").toLowerCase() !== "available") {
-        skippedBarcodes.push(barcode);
-        continue;
-      }
-
       if (isAdminReturn) {
-        if (!gear.checked_out_by) continue;
+        const normalizedStatus = String(gear.status ?? "").toLowerCase();
+        if (!gear.checked_out_by || normalizedStatus !== "checked_out") {
+          skippedBarcodes.push(barcode);
+          continue;
+        }
 
         const { data: updatedGear, error: updateError } = await adminClient
           .from("gear")
@@ -301,8 +300,9 @@ serve(async (req) => {
         continue;
       }
 
-      const isCheckout = !gear.checked_out_by;
-      const isReturn = gear.checked_out_by === student!.id;
+      const normalizedStatus = String(gear.status ?? "").toLowerCase();
+      const isCheckout = normalizedStatus === "available" && !gear.checked_out_by;
+      const isReturn = normalizedStatus === "checked_out" && gear.checked_out_by === student!.id;
 
       if (!isCheckout && !isReturn) {
         skippedBarcodes.push(barcode);

--- a/tests/e2e/checkout-borrower-ownership.spec.ts
+++ b/tests/e2e/checkout-borrower-ownership.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockAdminOps,
+  mockSystemStatus,
+  navigateApp,
+  setTenantAdminSession,
+} from "./helpers/testHarness";
+
+test.describe("Checkout borrower ownership regression", () => {
+  test("checkout by borrower A, borrower B blocked, return by borrower A allowed", async ({
+    page,
+  }) => {
+    await mockSystemStatus(page);
+    await mockAdminOps(page);
+
+    let checkedOutBy: string | null = null;
+    const borrowerByStudentId: Record<string, { id: string; username: string; student_id: string }> = {
+      BRWRA: { id: "student-a", username: "Borrower A", student_id: "BRWRA" },
+      BRWRB: { id: "student-b", username: "Borrower B", student_id: "BRWRB" },
+    };
+
+    await page.route("**/rest/v1/students?**", async (route) => {
+      const url = new URL(route.request().url());
+      const studentIdFilter = url.searchParams.get("student_id");
+      const studentId = studentIdFilter?.replace("eq.", "") ?? "";
+      const row = borrowerByStudentId[studentId];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(row ? [row] : []),
+      });
+    });
+
+    await page.route("**/rest/v1/gear?**", async (route) => {
+      const url = new URL(route.request().url());
+      const barcodeFilter = url.searchParams.get("barcode");
+      const checkedOutByFilter = url.searchParams.get("checked_out_by");
+      const checkedOutByStudent = checkedOutByFilter?.replace("eq.", "") ?? "";
+
+      const gearRow = {
+        id: "gear-1",
+        name: "Camera A",
+        barcode: "ITEM-1",
+        status: checkedOutBy ? "checked_out" : "available",
+      };
+
+      if (barcodeFilter) {
+        const barcode = barcodeFilter.replace("eq.", "");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(barcode === "ITEM-1" ? [gearRow] : []),
+        });
+        return;
+      }
+
+      if (checkedOutByFilter) {
+        const rows = checkedOutBy === checkedOutByStudent ? [gearRow] : [];
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(rows),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route(/\/functions(?:\/v1)?\/checkoutReturn(?:\?.*)?$/, async (route) => {
+      const body = route.request().postDataJSON() as {
+        student_id: string;
+        gear_barcodes: string[];
+      };
+      const borrowerId = body.student_id;
+      const barcode = body.gear_barcodes[0];
+
+      if (barcode !== "ITEM-1") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, processed: 0, skipped_barcodes: [barcode] }),
+        });
+        return;
+      }
+
+      if (!checkedOutBy) {
+        checkedOutBy = borrowerByStudentId[borrowerId]?.id ?? null;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, processed: 1, skipped_barcodes: [] }),
+        });
+        return;
+      }
+
+      if (checkedOutBy === borrowerByStudentId[borrowerId]?.id) {
+        checkedOutBy = null;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, processed: 1, skipped_barcodes: [] }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, processed: 0, skipped_barcodes: ["ITEM-1"] }),
+      });
+    });
+
+    await page.goto("/");
+    await page.evaluate(() => {
+      window.localStorage.setItem("itemtraxx:onboarding:v1:tenant_user", new Date().toISOString());
+      window.localStorage.setItem("itemtraxx:onboarding:v1:tenant_admin", new Date().toISOString());
+      window.localStorage.setItem(
+        "itemtraxx-cookie-consent",
+        JSON.stringify({
+          version: 1,
+          choice: "all",
+          updatedAt: new Date().toISOString(),
+        })
+      );
+    });
+    await setTenantAdminSession(page, "tenant-e2e");
+    await navigateApp(page, "/tenant/checkout");
+    await expect(page).toHaveURL(/\/tenant\/checkout$/);
+
+    const borrowerInput = page.getByPlaceholder("Enter borrower ID");
+    const loadBorrowerButton = page.getByRole("button", { name: "Load borrower" });
+    const barcodeInput = page.getByPlaceholder("Scan or enter barcode");
+    const addBarcodeButton = page.getByRole("button", { name: "Add barcode" });
+    const completeTransactionButton = page.getByRole("button", { name: "Complete transaction" });
+
+    // 1) Checkout by borrower A.
+    await borrowerInput.fill("BRWRA");
+    await loadBorrowerButton.click();
+    await expect(page.getByText("Borrower A")).toBeVisible();
+    await barcodeInput.fill("ITEM-1");
+    await addBarcodeButton.click();
+    await expect(page.getByText("Checkout")).toBeVisible();
+    await completeTransactionButton.click();
+    await expect(page.getByText("Transaction complete (Success).")).toBeVisible();
+
+    // 2) Borrower B cannot checkout/return while item is checked out by A.
+    await borrowerInput.fill("BRWRB");
+    await loadBorrowerButton.click();
+    await expect(page.getByText("Borrower B")).toBeVisible();
+    await barcodeInput.fill("ITEM-1");
+    await addBarcodeButton.click();
+    await expect(page.locator(".error", { hasText: "Item already checked out." })).toBeVisible();
+
+    // 3) Borrower A can return their own checked-out item.
+    await borrowerInput.fill("BRWRA");
+    await loadBorrowerButton.click();
+    await expect(page.getByText("Borrower A")).toBeVisible();
+    await barcodeInput.fill("ITEM-1");
+    await addBarcodeButton.click();
+    await expect(page.getByText("Return")).toBeVisible();
+    await completeTransactionButton.click();
+    await expect(page.getByText("Transaction complete (Success).")).toBeVisible();
+  });
+});

--- a/tests/e2e/checkout-borrower-ownership.spec.ts
+++ b/tests/e2e/checkout-borrower-ownership.spec.ts
@@ -137,11 +137,17 @@ test.describe("Checkout borrower ownership regression", () => {
     const barcodeInput = page.getByPlaceholder("Scan or enter barcode");
     const addBarcodeButton = page.getByRole("button", { name: "Add barcode" });
     const completeTransactionButton = page.getByRole("button", { name: "Complete transaction" });
+    const loadBorrower = async (id: "BRWRA" | "BRWRB") => {
+      await borrowerInput.fill(id);
+      await Promise.all([
+        page.waitForResponse((response) => response.url().includes("/rest/v1/students?") && response.ok()),
+        loadBorrowerButton.click(),
+      ]);
+      await expect(barcodeInput).toBeVisible();
+    };
 
     // 1) Checkout by borrower A.
-    await borrowerInput.fill("BRWRA");
-    await loadBorrowerButton.click();
-    await expect(page.getByText("Borrower A")).toBeVisible();
+    await loadBorrower("BRWRA");
     await barcodeInput.fill("ITEM-1");
     await addBarcodeButton.click();
     await expect(page.getByText("Checkout")).toBeVisible();
@@ -149,17 +155,13 @@ test.describe("Checkout borrower ownership regression", () => {
     await expect(page.getByText("Transaction complete (Success).")).toBeVisible();
 
     // 2) Borrower B cannot checkout/return while item is checked out by A.
-    await borrowerInput.fill("BRWRB");
-    await loadBorrowerButton.click();
-    await expect(page.getByText("Borrower B")).toBeVisible();
+    await loadBorrower("BRWRB");
     await barcodeInput.fill("ITEM-1");
     await addBarcodeButton.click();
     await expect(page.locator(".error", { hasText: "Item already checked out." })).toBeVisible();
 
     // 3) Borrower A can return their own checked-out item.
-    await borrowerInput.fill("BRWRA");
-    await loadBorrowerButton.click();
-    await expect(page.getByText("Borrower A")).toBeVisible();
+    await loadBorrower("BRWRA");
     await barcodeInput.fill("ITEM-1");
     await addBarcodeButton.click();
     await expect(page.getByText("Return")).toBeVisible();

--- a/tests/e2e/checkout-borrower-ownership.spec.ts
+++ b/tests/e2e/checkout-borrower-ownership.spec.ts
@@ -139,10 +139,9 @@ test.describe("Checkout borrower ownership regression", () => {
     const completeTransactionButton = page.getByRole("button", { name: "Complete transaction" });
     const loadBorrower = async (id: "BRWRA" | "BRWRB") => {
       await borrowerInput.fill(id);
-      await Promise.all([
-        page.waitForResponse((response) => response.url().includes("/rest/v1/students?") && response.ok()),
-        loadBorrowerButton.click(),
-      ]);
+      await loadBorrowerButton.click();
+      await expect(page.locator(".checkout-student-summary")).toBeVisible();
+      await expect(page.getByText(`ID: ${id}`)).toBeVisible();
       await expect(barcodeInput).toBeVisible();
     };
 

--- a/tests/e2e/checkout-borrower-ownership.spec.ts
+++ b/tests/e2e/checkout-borrower-ownership.spec.ts
@@ -149,7 +149,7 @@ test.describe("Checkout borrower ownership regression", () => {
     await loadBorrower("BRWRA");
     await barcodeInput.fill("ITEM-1");
     await addBarcodeButton.click();
-    await expect(page.getByText("Checkout")).toBeVisible();
+    await expect(page.locator(".tag-checkout", { hasText: "Checkout" })).toBeVisible();
     await completeTransactionButton.click();
     await expect(page.getByText("Transaction complete (Success).")).toBeVisible();
 
@@ -163,7 +163,7 @@ test.describe("Checkout borrower ownership regression", () => {
     await loadBorrower("BRWRA");
     await barcodeInput.fill("ITEM-1");
     await addBarcodeButton.click();
-    await expect(page.getByText("Return")).toBeVisible();
+    await expect(page.locator(".tag-return", { hasText: "Return" })).toBeVisible();
     await completeTransactionButton.click();
     await expect(page.getByText("Transaction complete (Success).")).toBeVisible();
   });


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to the checkout and return process, particularly around borrower ownership validation and error handling. It also adds a new end-to-end test to prevent regressions in borrower-specific checkout/return logic. The most important changes are grouped below:

**Checkout/Return Logic and Validation:**

* Refined the logic in `Checkout.vue` so that only items with status "available" can be checked out, and only the current borrower can return an item with status "checked_out". Borrowers who are not the current holder are now blocked from returning items they do not own, with clearer error messages.
* Improved the backend function (`checkoutReturn/index.ts`) to ensure that only items with the correct status and borrower association are processed for checkout or return, both for normal and admin returns. [[1]](diffhunk://#diff-d7a68e01b7faa1045d61c6e1e5b32d8cd41850301497b51a5d6e37511f6e9571L267-L274) [[2]](diffhunk://#diff-d7a68e01b7faa1045d61c6e1e5b32d8cd41850301497b51a5d6e37511f6e9571L304-R305)

**Error Handling and Robustness:**

* Enhanced error handling in `checkoutService.ts` by surfacing backend error and message fields, and retrying failed requests immediately if the network is online before falling back to offline queuing. [[1]](diffhunk://#diff-7c06e3cb2824016bd69cbc3035bbd09cd210f6e198affd3437ffa5b662d47f72R24-R25) [[2]](diffhunk://#diff-7c06e3cb2824016bd69cbc3035bbd09cd210f6e198affd3437ffa5b662d47f72R109-R112) [[3]](diffhunk://#diff-7c06e3cb2824016bd69cbc3035bbd09cd210f6e198affd3437ffa5b662d47f72R125-R132)
* Added a `waitForPendingSync` utility in `Checkout.vue` to ensure all pending sync operations complete before proceeding with a new checkout/return, reducing the risk of race conditions. [[1]](diffhunk://#diff-ff61622c257599ce1d464f8664b702e285dba5b6a284f4b086207a6c58f6d4c2R277-R283) [[2]](diffhunk://#diff-ff61622c257599ce1d464f8664b702e285dba5b6a284f4b086207a6c58f6d4c2R443-R450)

**Testing and Configuration:**

* Added a new end-to-end regression test (`checkout-borrower-ownership.spec.ts`) to verify that only the borrower who checked out an item can return it, and that other borrowers are blocked from returning or checking out already checked-out items.
* Updated Playwright test configuration to support an edge proxy URL via a new environment variable, improving test environment flexibility. [[1]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R11) [[2]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R33)


Summary generated by Copilot.