### PR TITLE
Update changelog through 5/23/2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-Last updated (year-month-day): 2026-05-19
+Last updated (year-month-day): 2026-05-23
 
 This changelog summarizes notable ItemTraxx product, reliability, security, and experience updates.
 
 Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
+
+### 5/21/2026 Development Update
+
+- Completed routine dependency maintenance and security-related dependency updates.
+- Verified the app dependency audit gate after dependency updates.
 
 ### 5/19/2026 Development Update
 


### PR DESCRIPTION
## Summary
- update the public changelog with the latest public-facing development entry after 2026-05-19
- skip days with no public-facing changes

## Validation
- changelog-only update