### PR TITLE
Add incident.io workflow alerts

### DIFF
--- a/.github/workflows/async-job-worker.yml
+++ b/.github/workflows/async-job-worker.yml
@@ -57,3 +57,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - process-jobs
+    if: ${{ always() && (needs.process-jobs.result == 'failure' || needs.process-jobs.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.process-jobs.result }}
+      severity: high
+      workflow_name: Async Job Worker
+      job_name: process-jobs
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -89,3 +89,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - build-and-verify
+    if: ${{ always() && github.event_name != 'pull_request' && (needs.build-and-verify.result == 'failure' || needs.build-and-verify.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.build-and-verify.result }}
+      severity: high
+      workflow_name: CI Core
+      job_name: build-and-verify
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -91,3 +91,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - analyze
+    if: ${{ always() && github.event_name != 'pull_request' && (needs.analyze.result == 'failure' || needs.analyze.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.analyze.result }}
+      severity: high
+      workflow_name: CodeQL
+      job_name: analyze
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -72,3 +72,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - deploy
+    if: ${{ always() && (needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.deploy.result }}
+      severity: high
+      workflow_name: Deploy Cloudflare Worker
+      job_name: deploy
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -90,3 +90,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - deploy
+    if: ${{ always() && (needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.deploy.result }}
+      severity: high
+      workflow_name: Deploy Supabase Functions
+      job_name: deploy
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/deployment-health.yml
+++ b/.github/workflows/deployment-health.yml
@@ -118,3 +118,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - health-check
+    if: ${{ always() && (needs.health-check.result == 'failure' || needs.health-check.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.health-check.result }}
+      severity: high
+      workflow_name: Deployment Health
+      job_name: health-check
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,3 +97,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - e2e
+    if: ${{ always() && github.event_name != 'pull_request' && (needs.e2e.result == 'failure' || needs.e2e.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.e2e.result }}
+      severity: high
+      workflow_name: E2E Tests
+      job_name: e2e
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/incidentio-workflow-alert.yml
+++ b/.github/workflows/incidentio-workflow-alert.yml
@@ -1,0 +1,112 @@
+name: incident.io Workflow Alert
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        required: true
+        type: string
+      severity:
+        required: false
+        type: string
+        default: high
+      workflow_name:
+        required: true
+        type: string
+      job_name:
+        required: true
+        type: string
+      run_url:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+      branch:
+        required: false
+        type: string
+        default: unknown
+      sha:
+        required: false
+        type: string
+        default: unknown
+      environment:
+        required: false
+        type: string
+        default: production
+    secrets:
+      INCIDENT_IO_WEBHOOK_URL:
+        required: false
+      INCIDENT_IO_WEBHOOK_TOKEN:
+        required: false
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send incident.io workflow alert
+        env:
+          INCIDENT_IO_WEBHOOK_URL: ${{ secrets.INCIDENT_IO_WEBHOOK_URL }}
+          INCIDENT_IO_WEBHOOK_TOKEN: ${{ secrets.INCIDENT_IO_WEBHOOK_TOKEN }}
+          STATUS: ${{ inputs.status }}
+          SEVERITY: ${{ inputs.severity }}
+          WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          JOB_NAME: ${{ inputs.job_name }}
+          RUN_URL: ${{ inputs.run_url }}
+          REPOSITORY: ${{ inputs.repository }}
+          BRANCH: ${{ inputs.branch }}
+          SHA: ${{ inputs.sha }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${INCIDENT_IO_WEBHOOK_URL:-}" ]; then
+            echo "INCIDENT_IO_WEBHOOK_URL is not configured; skipping incident.io alert."
+            exit 0
+          fi
+
+          if [ -z "${INCIDENT_IO_WEBHOOK_TOKEN:-}" ]; then
+            echo "INCIDENT_IO_WEBHOOK_TOKEN is not configured; skipping incident.io alert."
+            exit 0
+          fi
+
+          SHORT_SHA="$(printf '%s' "$SHA" | cut -c1-7)"
+          DEDUPE_KEY="${REPOSITORY}:${WORKFLOW_NAME}:${JOB_NAME}:${BRANCH}"
+
+          jq -n \
+            --arg title "GitHub Actions workflow ${STATUS}: ${WORKFLOW_NAME} / ${JOB_NAME}" \
+            --arg workflow_status "$STATUS" \
+            --arg severity "$SEVERITY" \
+            --arg workflow "$WORKFLOW_NAME" \
+            --arg job "$JOB_NAME" \
+            --arg repo "$REPOSITORY" \
+            --arg branch "$BRANCH" \
+            --arg sha "$SHA" \
+            --arg short_sha "$SHORT_SHA" \
+            --arg run_url "$RUN_URL" \
+            --arg environment "$ENVIRONMENT" \
+            --arg dedupe_key "$DEDUPE_KEY" \
+            '{
+              title: $title,
+              description: ("GitHub Actions workflow `" + $workflow + "` job `" + $job + "` in `" + $repo + "` is `" + $workflow_status + "` on branch `" + $branch + "`."),
+              deduplication_key: $dedupe_key,
+              status: "firing",
+              metadata: {
+                workflow_status: $workflow_status,
+                severity: $severity,
+                repository: $repo,
+                workflow: $workflow,
+                job: $job,
+                branch: $branch,
+                sha: $sha,
+                short_sha: $short_sha,
+                run_url: $run_url,
+                environment: $environment
+              }
+            }' \
+          | curl -fsSL -X POST "$INCIDENT_IO_WEBHOOK_URL" \
+              -H "Authorization: Bearer ${INCIDENT_IO_WEBHOOK_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data-binary @-

--- a/.github/workflows/schedule-watchdog.yml
+++ b/.github/workflows/schedule-watchdog.yml
@@ -29,6 +29,32 @@ jobs:
           STALE_REPORT=""
           HEARTBEAT_REPORT=""
 
+          fetch_workflow_runs() {
+            local workflow_file="$1"
+            local url="${API_BASE}/actions/workflows/${workflow_file}/runs?event=schedule&branch=main&status=completed&per_page=50"
+            local attempt
+            local max_attempts=4
+            local delay_seconds=5
+
+            for attempt in $(seq 1 "$max_attempts"); do
+              if curl -fsSL \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "$url"; then
+                return 0
+              fi
+
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                echo "GitHub API request for ${workflow_file} failed on attempt ${attempt}; retrying in ${delay_seconds}s..." >&2
+                sleep "$delay_seconds"
+                delay_seconds="$(( delay_seconds * 2 ))"
+              fi
+            done
+
+            echo "GitHub API request for ${workflow_file} failed after ${max_attempts} attempts." >&2
+            return 1
+          }
+
           check_workflow() {
             local workflow_file="$1"
             local workflow_name="$2"
@@ -36,10 +62,7 @@ jobs:
             local success_max_age_seconds="$4"
 
             local response
-            response="$(curl -fsSL \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "${API_BASE}/actions/workflows/${workflow_file}/runs?event=schedule&branch=main&status=completed&per_page=50")"
+            response="$(fetch_workflow_runs "$workflow_file")"
 
             local latest_completed
             latest_completed="$(printf '%s' "$response" | jq -r '

--- a/.github/workflows/schedule-watchdog.yml
+++ b/.github/workflows/schedule-watchdog.yml
@@ -205,3 +205,20 @@ jobs:
           curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "$PAYLOAD"
+
+  incidentio-notify-failure:
+    needs:
+      - check-stale-schedules
+    if: ${{ always() && (needs.check-stale-schedules.result == 'failure' || needs.check-stale-schedules.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.check-stale-schedules.result }}
+      severity: high
+      workflow_name: Schedule Watchdog
+      job_name: check-stale-schedules
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -76,3 +76,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - security-audit
+    if: ${{ always() && github.event_name != 'pull_request' && (needs.security-audit.result == 'failure' || needs.security-audit.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.security-audit.result }}
+      severity: high
+      workflow_name: Security Audit
+      job_name: security-audit
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -50,3 +50,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - synthetic-smoke
+    if: ${{ always() && (needs.synthetic-smoke.result == 'failure' || needs.synthetic-smoke.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.synthetic-smoke.result }}
+      severity: high
+      workflow_name: Synthetic Journeys
+      job_name: synthetic-smoke
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a reusable incident.io workflow alert sender for GitHub Actions failures
- wire failure alerts into critical CI, deploy, scheduled, watchdog, and synthetic workflows
- add GitHub API retry handling to the schedule watchdog API lookup

## Validation
- parsed all workflow YAML files locally with Ruby YAML
- ran git diff --check