### PR TITLE
Extend incident.io workflow alerts

### DIFF
--- a/.github/workflows/manage-kill-switch.yml
+++ b/.github/workflows/manage-kill-switch.yml
@@ -125,3 +125,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - apply
+    if: ${{ always() && (needs.apply.result == 'failure' || needs.apply.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.apply.result }}
+      severity: high
+      workflow_name: Manage Kill Switch
+      job_name: apply
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/slack-notify-failure.yml
+++ b/.github/workflows/slack-notify-failure.yml
@@ -23,6 +23,10 @@ on:
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
+      INCIDENT_IO_WEBHOOK_URL:
+        required: false
+      INCIDENT_IO_WEBHOOK_TOKEN:
+        required: false
 
 jobs:
   notify:
@@ -85,3 +89,20 @@ jobs:
           curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "$PAYLOAD"
+
+  incidentio-notify-failure:
+    needs:
+      - notify
+    if: ${{ always() && (needs.notify.result == 'failure' || needs.notify.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.notify.result }}
+      severity: high
+      workflow_name: Slack Notify Failure
+      job_name: notify
+      run_url: ${{ inputs.run_url }}
+      repository: ${{ github.repository }}
+      branch: ${{ inputs.ref_name }}
+      sha: ${{ inputs.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/slack-notify-status.yml
+++ b/.github/workflows/slack-notify-status.yml
@@ -48,6 +48,10 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: false
+      INCIDENT_IO_WEBHOOK_URL:
+        required: false
+      INCIDENT_IO_WEBHOOK_TOKEN:
+        required: false
 
 jobs:
   notify_start:
@@ -145,6 +149,23 @@ jobs:
           fi
 
           send_webhook_fallback
+
+  incidentio-notify-start-failure:
+    needs:
+      - notify_start
+    if: ${{ always() && inputs.mode == 'start' && (needs.notify_start.result == 'failure' || needs.notify_start.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.notify_start.result }}
+      severity: high
+      workflow_name: Slack Notify Status
+      job_name: notify_start
+      run_url: ${{ inputs.run_url }}
+      repository: ${{ github.repository }}
+      branch: ${{ inputs.ref_name }}
+      sha: ${{ inputs.sha }}
+      environment: production
+    secrets: inherit
 
   notify_finish:
     if: ${{ inputs.mode == 'finish' }}
@@ -282,3 +303,20 @@ jobs:
           fi
 
           send_webhook_fallback
+
+  incidentio-notify-finish-failure:
+    needs:
+      - notify_finish
+    if: ${{ always() && inputs.mode == 'finish' && (needs.notify_finish.result == 'failure' || needs.notify_finish.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.notify_finish.result }}
+      severity: high
+      workflow_name: Slack Notify Status
+      job_name: notify_finish
+      run_url: ${{ inputs.run_url }}
+      repository: ${{ github.repository }}
+      branch: ${{ inputs.ref_name }}
+      sha: ${{ inputs.sha }}
+      environment: production
+    secrets: inherit

--- a/.github/workflows/vercel-analytics-report.yml
+++ b/.github/workflows/vercel-analytics-report.yml
@@ -65,3 +65,20 @@ jobs:
       slack_channel_id: ${{ needs.slack-notify-start.outputs.slack_channel_id }}
       slack_message_ts: ${{ needs.slack-notify-start.outputs.slack_message_ts }}
     secrets: inherit
+
+  incidentio-notify-failure:
+    needs:
+      - analyze
+    if: ${{ always() && (needs.analyze.result == 'failure' || needs.analyze.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
+    with:
+      status: ${{ needs.analyze.result }}
+      severity: high
+      workflow_name: Vercel Analytics Report
+      job_name: analyze
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      environment: production
+    secrets: inherit


### PR DESCRIPTION
## Summary
- send incident.io alerts when Slack notification reusable workflows fail
- add incident.io failure alerts to Manage Kill Switch
- add incident.io failure alerts to Vercel Analytics Report

## Validation
- parsed all workflow YAML files locally with Ruby YAML
- ran git diff --check